### PR TITLE
Removed unsupported gem for Ruby 3.3

### DIFF
--- a/.idea/github-build.iml
+++ b/.idea/github-build.iml
@@ -9,34 +9,43 @@
       <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
     </content>
-    <orderEntry type="jdk" jdkName="rbenv: 3.3.0" jdkType="RUBY_SDK" />
+    <orderEntry type="jdk" jdkName="ruby-3.3.1-p55" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v7.1.3.2, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bigdecimal (v3.1.7, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.5.4, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.2.3, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.4.1, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="drb (v2.2.1, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="duplicate (v1.1.1, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="httparty (v0.21.0, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.4, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="json (v2.7.2, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.3, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.22.3, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="multi_xml (v0.6.0, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="open3 (v0.2.1, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.24.0, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parser (v3.3.0.5, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="psych (v5.1.2, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="racc (v1.7.3, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.9.0, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.6, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.31.2, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.13.0, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, rbenv: 3.3.0) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.5.0, rbenv: 3.3.0) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v7.1.3.3, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bigdecimal (v3.1.8, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.5.9, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.3.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.4.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="csv (v3.3.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="drb (v2.2.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="duplicate (v1.1.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="httparty (v0.22.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.5, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="json (v2.7.2, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="language_server-protocol (v3.17.0.3, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="minitest (v5.23.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="multi_xml (v0.7.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="open3 (v0.2.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="optparse (v0.5.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.24.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parser (v3.3.2.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="psych (v5.1.2, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="racc (v1.8.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.9.2, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.8, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.64.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.31.3, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-capybara (v2.20.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-factory_bot (v2.25.1, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-performance (v1.21.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec (v2.29.2, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec_rails (v2.28.3, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.13.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="strscan (v3.1.0, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, ruby-3.3.1-p55) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.5.0, ruby-3.3.1-p55) [gem]" level="application" />
   </component>
 </module>

--- a/.soup.json
+++ b/.soup.json
@@ -116,8 +116,8 @@
     "website": "https://github.com/ruby/fileutils",
     "last_verified_at": "2023-06-12",
     "risk_level": "Low",
-    "requirements": "File utilities",
-    "verification_reasoning": "Most popular gem on rubygems"
+    "requirements": "Dependency",
+    "verification_reasoning": "Dependency"
   },
   "httparty": {
     "language": "Ruby",

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '>= 7.0.0'
 gem 'duplicate', '>= 1.1.1'
-gem 'fileutils', '>= 1.7.1'
 gem 'httparty', '>= 0.21.0'
 gem 'open3', '>= 0.1.2'
 gem 'optparse', '>= 0.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,6 @@ GEM
     csv (3.3.0)
     drb (2.2.1)
     duplicate (1.1.1)
-    fileutils (1.7.2)
     httparty (0.22.0)
       csv
       mini_mime (>= 1.0.0)
@@ -90,7 +89,6 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 7.0.0)
   duplicate (>= 1.1.1)
-  fileutils (>= 1.7.1)
   httparty (>= 0.21.0)
   open3 (>= 0.1.2)
   optparse (>= 0.3.1)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -11,7 +11,7 @@
 | Ruby | csv | 3.3.0 | Ruby | The CSV library provides a complete interface to CSV files and data | <https://github.com/ruby/csv> | 2024-04-29 | Low | Dependency | Dependency |
 | Ruby | drb | 2.2.1 | Ruby | Distributed object system for Ruby | <https://github.com/ruby/drb> | 2023-10-16 | Low | Dependency | Dependency |
 | Ruby | duplicate | 1.1.1 | Apache License Version 2.0 | Originally extracted from rack-app project | <http://www.rack-app.com> | 2023-06-12 | Low | Handle deep clone | Most popular gem on rubygems |
-| Ruby | fileutils | 1.7.2 | Ruby | Several file utility methods for copying, moving, removing, etc. | <https://github.com/ruby/fileutils> | 2023-06-12 | Low | File utilities | Most popular gem on rubygems |
+| Ruby | fileutils | 1.7.2 | Ruby | Several file utility methods for copying, moving, removing, etc. | <https://github.com/ruby/fileutils> | 2023-06-12 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.22.0 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2023-06-12 | Low | HTTP access library | Most popular gem on rubygems |
 | Ruby | i18n | 1.14.5 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2023-06-12 | Low | Dependency | Dependency |
 | Ruby | json | 2.7.2 | Ruby | A JSON implementation as a JRuby extension. | <https://flori.github.io/json> | 2023-06-12 | Low | Dependency | Dependency |

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -177,10 +177,11 @@ module GHB
         puts("        Enabling #{linter[:short_name]}...")
         old_workflow = @old_workflow
 
-        if linter[:config] and !File.exist?(linter[:config])
+        if linter[:config]
           if File.exist?("#{script_path}/linters/#{linter[:config]}")
             FileUtils.ln_s("#{script_path}/linters/#{linter[:config]}", linter[:config], force: true)
           else
+            pp linter[:config]
             File.delete(linter[:config]) if File.symlink?(linter[:config]) or File.exist?(linter[:config])
             FileUtils.cp("#{__dir__}/../../config/linters/#{linter[:config]}", linter[:config])
           end

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -181,7 +181,6 @@ module GHB
           if File.exist?("#{script_path}/linters/#{linter[:config]}")
             FileUtils.ln_s("#{script_path}/linters/#{linter[:config]}", linter[:config], force: true)
           else
-            pp linter[:config]
             File.delete(linter[:config]) if File.symlink?(linter[:config]) or File.exist?(linter[:config])
             FileUtils.cp("#{__dir__}/../../config/linters/#{linter[:config]}", linter[:config])
           end

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -181,7 +181,7 @@ module GHB
           if File.exist?("#{script_path}/linters/#{linter[:config]}")
             FileUtils.ln_s("#{script_path}/linters/#{linter[:config]}", linter[:config], force: true)
           else
-            File.delete(linter[:config]) if File.symlink?(linter[:config])
+            File.delete(linter[:config]) if File.symlink?(linter[:config]) or File.exist?(linter[:config])
             FileUtils.cp("#{__dir__}/../../config/linters/#{linter[:config]}", linter[:config])
           end
         end


### PR DESCRIPTION
# Summary

Removed unsupported gem for Ruby 3.3.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
