### PR TITLE
pip: ignore nvidia-* dependencies in dependabot

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -650,7 +650,7 @@ module GHB
       @dependabot_package_managers.uniq!
       package_managers =
         @dependabot_package_managers.map do |package_manager|
-          {
+          data = {
             'package-ecosystem': package_manager,
             directory: '/',
             'open-pull-requests-limit': 0,
@@ -659,6 +659,14 @@ module GHB
                 interval: 'monthly'
               }
           }
+
+          if package_manager == 'pip'
+            data['ignore'] = [
+              'dependency-name': 'nvidia-*'
+            ]
+          end
+
+          data
         end
 
       File.write('.github/dependabot.yml', { version: 2, updates: package_managers }.deep_stringify_keys.to_yaml({ line_width: -1 }))


### PR DESCRIPTION
# Summary

Nvidia python packages are not installable on macos, so this PR makes dependabot not appending them to requirements.txt.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
