### PR TITLE
pip: skip nvidia cuda dependencies

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -261,7 +261,7 @@ python:
       elasticsearch_dependency: elasticsearch
       package_manager_name: Pip
       package_manager_default: pip install -r requirements.txt
-      package_manager_update: pip install pip-tools ; pip-compile --resolver=backtracking --upgrade
+      package_manager_update: pip install pip-tools ; pip-compile --resolver=backtracking --upgrade --strip-extras --unsafe-package pip --unsafe-package setuptools --unsafe-package nvidia-cublas-cu12 --unsafe-package nvidia-cuda-cupti-cu12 --unsafe-package nvidia-cuda-nvrtc-cu12 --unsafe-package nvidia-cuda-runtime-cu12 --unsafe-package nvidia-cudnn-cu12 --unsafe-package nvidia-cufft-cu12 --unsafe-package nvidia-cufile-cu12 --unsafe-package nvidia-curand-cu12 --unsafe-package nvidia-cusolver-cu12 --unsafe-package nvidia-cusparse-cu12 --unsafe-package nvidia-cusparselt-cu12 --unsafe-package nvidia-nccl-cu12 --unsafe-package nvidia-nvjitlink-cu12 --unsafe-package nvidia-nvtx-cu12
       dependabot_ecosystem: pip
   unit_test_framework_name: Coverage
   unit_test_framework_default: coverage run -m unittest


### PR DESCRIPTION
# Summary

This makes `pip-compile` ignore nvidia cuda packages, which are not installable on macos.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
