### PR TITLE
Remove obsolete gitignore entries and disable GHAS for private repos

### DIFF
--- a/config/gitignore.yaml
+++ b/config/gitignore.yaml
@@ -90,14 +90,6 @@ extension_detection:
     directories:
       - roles
       - playbooks
-  applescript:
-    extensions:
-      - applescript
-      - scpt
-  assemblylanguage:
-    extensions:
-      - asm
-      - s
   astro:
     extensions:
       - astro
@@ -142,11 +134,6 @@ extension_detection:
       - CMakeLists.txt
     extensions:
       - cmake
-  cobol:
-    extensions:
-      - cob
-      - cbl
-      - cpy
   coffeescript:
     extensions:
       - coffee
@@ -167,9 +154,6 @@ extension_detection:
     extensions:
       - cs
       - csx
-  css:
-    extensions:
-      - css
   cuda:
     extensions:
       - cu
@@ -197,15 +181,6 @@ extension_detection:
     extensions:
       - dm
       - dme
-  docker:
-    files:
-      - Dockerfile
-      - docker-compose.yml
-      - docker-compose.yaml
-      - compose.yml
-      - compose.yaml
-    extensions:
-      - dockerfile
   dotenv:
     files:
       - .env
@@ -228,9 +203,6 @@ extension_detection:
     extensions:
       - brd
       - sch
-  eiffel:
-    extensions:
-      - e
   elisp:
     extensions:
       - el
@@ -264,9 +236,6 @@ extension_detection:
   expressionengine:
     directories:
       - system/expressionengine
-  factor:
-    extensions:
-      - factor
   flask:
     directories:
       - templates
@@ -325,10 +294,6 @@ extension_detection:
       - grails-app
     directories:
       - grails-app
-  graphql:
-    extensions:
-      - graphql
-      - gql
   groovy:
     extensions:
       - groovy
@@ -381,9 +346,6 @@ extension_detection:
       - _layouts
       - _includes
       - _sass
-  jenkins:
-    files:
-      - Jenkinsfile
   joomla:
     files:
       - configuration.php
@@ -522,11 +484,6 @@ extension_detection:
   opa:
     extensions:
       - rego
-  pascal:
-    extensions:
-      - pas
-      - pp
-      - inc
   perl:
     extensions:
       - pl
@@ -548,13 +505,6 @@ extension_detection:
     directories:
       - priv/static
       - priv/repo
-  php:
-    extensions:
-      - php
-      - phtml
-    files:
-      - composer.json
-      - composer.lock
   playframework:
     files:
       - build.sbt
@@ -570,10 +520,6 @@ extension_detection:
       - ps1
       - psm1
       - psd1
-  premake:
-    files:
-      - premake5.lua
-      - premake4.lua
   prestashop:
     files:
       - config/defines.inc.php
@@ -581,13 +527,6 @@ extension_detection:
   processing:
     extensions:
       - pde
-  prolog:
-    extensions:
-      - pl
-      - pro
-  protobuf:
-    extensions:
-      - proto
   puppet:
     extensions:
       - pp
@@ -650,10 +589,6 @@ extension_detection:
     directories:
       - android
       - ios
-  reason:
-    extensions:
-      - re
-      - rei
   redis:
     files:
       - redis.conf
@@ -777,9 +712,6 @@ extension_detection:
       - svelte
     files:
       - svelte.config.js
-  svg:
-    extensions:
-      - svg
   swift:
     extensions:
       - swift
@@ -791,10 +723,6 @@ extension_detection:
     files:
       - symfony.lock
       - config/bundles.php
-  tailwindcss:
-    files:
-      - tailwind.config.js
-      - tailwind.config.ts
   terraform:
     extensions:
       - tf
@@ -825,9 +753,6 @@ extension_detection:
       - production.ini
     directories:
       - tg2env
-  twig:
-    extensions:
-      - twig
   typo3:
     directories:
       - typo3conf
@@ -846,16 +771,9 @@ extension_detection:
       - uproject
       - uasset
       - umap
-  v:
-    extensions:
-      - v
   vagrant:
     files:
       - Vagrantfile
-  vala:
-    extensions:
-      - vala
-      - vapi
   vapor:
     files:
       - Sources/App/configure.swift
@@ -866,10 +784,6 @@ extension_detection:
   vcpkg:
     files:
       - vcpkg.json
-  vhdl:
-    extensions:
-      - vhd
-      - vhdl
   video:
     extensions:
       - mp4
@@ -909,14 +823,6 @@ extension_detection:
   waf:
     files:
       - wscript
-  webassembly:
-    extensions:
-      - wat
-      - wasm
-  webpack:
-    files:
-      - webpack.config.js
-      - webpack.config.ts
   wordpress:
     files:
       - wp-config.php
@@ -932,12 +838,6 @@ extension_detection:
     files:
       - Podfile
       - Cartfile
-  xamarin:
-    extensions:
-      - csproj
-    directories:
-      - Droid
-      - iOS
   xilinx:
     extensions:
       - xpr
@@ -1021,41 +921,12 @@ extension_detection:
       - template.yaml
       - template.yml
       - samconfig.toml
-  # AWS CDK
-  awscdk:
-    files:
-      - cdk.json
-    directories:
-      - cdk.out
-  # Nx monorepo
-  nx:
-    files:
-      - nx.json
-      - workspace.json
-  # Lerna monorepo
-  lerna:
-    files:
-      - lerna.json
-  # Turborepo
-  turborepo:
-    files:
-      - turbo.json
-  # pnpm
-  pnpm:
-    files:
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
   # Yarn
   yarn:
     files:
       - yarn.lock
       - .yarnrc.yml
       - .yarnrc
-  # Bun
-  bun:
-    files:
-      - bun.lockb
-      - bunfig.toml
   # Deno
   deno:
     files:


### PR DESCRIPTION
# Summary

This PR includes two main changes:

1. **Gitignore template cleanup**: Removed detection configurations for technologies that don't have corresponding gitignore templates in the GitHub gitignore repository. This eliminates false positive detections for languages/frameworks like AppleScript, Assembly, COBOL, CSS, Docker, Eiffel, Factor, GraphQL, Jenkins, Pascal, PHP, Prolog, Protobuf, Reason, SVG, Tailwind CSS, Twig, V, Vala, VHDL, WebAssembly, Webpack, Xamarin, AWS CDK, Nx, Lerna, Turborepo, pnpm, Bun, and Premake.

2. **GHAS billing protection for private repositories**: Modified the repository configuration logic to automatically disable GitHub Advanced Security (GHAS) features (secret scanning, CodeQL) for private repositories to avoid incurring charges. Public repositories will continue to have these features enabled since they're free.

3. **Rubocop Rails config fix**: Fixed a regex bug in the `.rubocop.yml` Rails configuration uncomment logic. The previous pattern `'# '` would incorrectly strip comment prefixes regardless of indentation, while the new regex `/^(\s*)# /` properly preserves leading whitespace when uncommenting lines.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

The GHAS feature toggle based on repository visibility is important for cost management. GitHub Advanced Security features (secret scanning, push protection, CodeQL) are free for public repositories but incur per-committer charges for private repositories. This change ensures private repositories don't unexpectedly enable billable features during repository configuration.
