### PR TITLE
Add AI assistants gitignore patterns unconditionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ flycheck_*.el
 
 # network security
 /network-security.data
+
 ### JetBrains ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
@@ -514,4 +515,20 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,rubymine,sublimetext,vim,visualstudiocode,windows
+
+# BEGIN AI Assistants
+
+# Claude Code
+.claude/
+
+# Cursor
+.cursor/
+
+# GitHub Copilot
+.copilot/
+
+# OpenAI Codex
+.codex/
+
+# END AI Assistants
 

--- a/config/gitignore.yaml
+++ b/config/gitignore.yaml
@@ -3,49 +3,24 @@
 # Detection is based on SOURCE files, not build artifacts
 
 # Custom patterns for tools not available on gitignore.io
-# These are appended directly to .gitignore when detected
+# These are always appended to .gitignore to prevent accidental commits
 custom_patterns:
   claudecode:
-    directories:
-      - .claude
     patterns:
       - "# Claude Code"
       - ".claude/"
   cursor:
-    directories:
-      - .cursor
     patterns:
       - "# Cursor"
       - ".cursor/"
   copilot:
-    directories:
-      - .github/copilot
-    files:
-      - .copilot-codereviews.yml
     patterns:
       - "# GitHub Copilot"
       - ".copilot/"
   openaicodex:
-    directories:
-      - .codex
     patterns:
       - "# OpenAI Codex"
       - ".codex/"
-  aider:
-    files:
-      - .aider.conf.yml
-      - .aiderignore
-    patterns:
-      - "# Aider"
-      - ".aider*"
-      - "!.aider.conf.yml"
-      - "!.aiderignore"
-  windsurf:
-    directories:
-      - .windsurf
-    patterns:
-      - "# Windsurf"
-      - ".windsurf/"
 
 # Templates that are always enabled (no detection needed)
 always_enabled:


### PR DESCRIPTION
# Summary

Simplify AI assistant gitignore pattern handling by always including all configured AI tool patterns (Claude Code, Cursor, GitHub Copilot, OpenAI Codex) rather than detecting tool presence. This prevents accidental commits of AI assistant configuration files even when developers haven't yet created those directories. Also improves the gitignore structure by adding clear `# BEGIN AI Assistants` and `# END AI Assistants` section markers, and removes less common AI tools (Aider, Windsurf) from the configuration.

Key changes:
- Remove detection logic for AI assistant directories/files - patterns are now always included
- Add section markers for the AI Assistants block in generated .gitignore files
- Restructure code to add AI section before preserving custom entries
- Remove Aider and Windsurf from custom patterns configuration
- Fix preservation of custom entries to properly skip regenerated AI section

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

The rationale for always including AI assistant patterns rather than detecting them:
1. Prevents accidental commits when a developer starts using a new AI tool
2. Simplifies the configuration by removing detection rules
3. The patterns are harmless if the directories don't exist
4. Reduces false negatives where AI tool directories weren't detected properly
