### PR TITLE
Remove skip_codeql option and related CodeQL skip logic

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -182,7 +182,6 @@ module GHB
       linters&.each do |short_name, linter|
         next if @options.ignored_linters[short_name]
 
-        next if linter[:short_name].include?('CodeQL') and @options.skip_codeql
         next if linter[:short_name].include?('Semgrep') and @options.skip_semgrep
 
         find_command = "find #{linter[:path]}"

--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -28,7 +28,6 @@ module GHB
       @options_config_file_redis = OPTIONS_REDIS_CONFIG_FILE
       @organization = Dir.pwd.split('/')[-2]
       @parser = OptionParser.new
-      @skip_codeql = false
       @skip_dependabot = false
       @skip_semgrep = false
       @skip_gitignore = false
@@ -40,7 +39,7 @@ module GHB
       setup_parser
     end
 
-    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :only_dependabot, :options_config_file_apt, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_codeql, :skip_dependabot, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check
+    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :only_dependabot, :options_config_file_apt, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_dependabot, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check
 
     def parse
       @parser.parse!(@argv)
@@ -130,10 +129,6 @@ module GHB
 
       @parser.on('', '--organization organization', 'GitHub organization') do |organization|
         @organization = organization
-      end
-
-      @parser.on('', '--skip_codeql', 'Skip CodeQL') do
-        @skip_codeql = true
       end
 
       @parser.on('', '--skip_semgrep', 'Skip Semgrep') do


### PR DESCRIPTION
# Summary

Remove CodeQL support from the application. This change removes the `--skip_codeql` command-line option and the associated logic that would skip CodeQL linters during processing. CodeQL-related functionality is no longer needed and has been cleaned up from both the options parser and the application logic.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [x] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

This is a breaking change for users who rely on the `--skip_codeql` command-line flag. Any scripts or workflows using this option will need to be updated to remove the flag.
