### PR TITLE
Remove ruby-version parameter when version file takes precedence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,6 @@ jobs:
         aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
         aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
         aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
-        ruby-version: "${{env.RUBY-VERSION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
         github-token: "${{secrets.GH_PAT}}"
     - name: Bundler

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,7 +23,6 @@ jobs:
         aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
         aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
         aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
-        ruby-version: "${{env.RUBY-VERSION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
         github-token: "${{secrets.GH_PAT}}"
     - name: Update Dependencies

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -64,8 +64,8 @@ module GHB
       workflow_write
       save_dependabot_config
       save_dockerhub_config
-      check_repository_settings
       update_gitignore
+      check_repository_settings
       @exit_code
     end
 
@@ -380,6 +380,12 @@ module GHB
             copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name), %i[id if uses run shell with env continue_on_error timeout_minutes])
             do_uses("cloud-officer/ci-actions/setup@#{CI_ACTIONS_VERSION}")
 
+            # Remove version parameter from with if version file exists (version file takes precedence)
+            if version_file
+              version_option_key = (version_file == '.nvmrc' ? 'node-version' : version_file.delete_prefix('.')).to_sym
+              with.delete(version_option_key)
+            end
+
             if with.empty?
               do_with(
                 {
@@ -487,7 +493,6 @@ module GHB
           end
 
           @new_workflow.env.delete(option[:name].upcase.to_sym)
-          puts("            Using version file #{version_file} for #{option[:name]}")
           next
         end
 


### PR DESCRIPTION
# Summary

This PR improves the version file handling logic in the workflow generation. When a version file (like `.ruby-version`) is present, the corresponding version parameter should not be passed to the CI actions, as the version file takes precedence.

**Key changes:**
- Remove explicit `ruby-version` parameter from `build.yml` and `dependencies.yml` workflows since `.ruby-version` file is used
- Add logic to remove version parameters from the `with` block when a version file exists
- Reorder `update_gitignore` to run before `check_repository_settings` for proper sequencing
- Remove redundant console output message about version file usage

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
