### PR TITLE
Update service default versions and fix regex escaping in gitignore config

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -446,7 +446,7 @@
   "rspec-support": {
     "language": "Ruby",
     "package": "rspec-support",
-    "version": "3.13.6",
+    "version": "3.13.7",
     "license": "MIT",
     "description": "Support utilities for RSpec gems",
     "website": "https://rspec.info",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.6)
+    rspec-support (3.13.7)
     rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -144,4 +144,4 @@ DEPENDENCIES
   webmock (>= 3.18.0)
 
 BUNDLED WITH
-  4.0.4
+  4.0.5

--- a/config/gitignore.yaml
+++ b/config/gitignore.yaml
@@ -99,7 +99,7 @@ extension_detection:
   django:
     packages:
       requirements.txt:
-        - "^[Dd]jango[=~<>![]"
+        - "^[Dd]jango[=~<>!\\[]"
       pyproject.toml:
         - '"[Dd]jango"'
   dotenv:
@@ -136,7 +136,7 @@ extension_detection:
   flask:
     packages:
       requirements.txt:
-        - "^[Ff]lask[=~<>![]"
+        - "^[Ff]lask[=~<>!\\[]"
       pyproject.toml:
         - '"[Ff]lask"'
   flutter:

--- a/config/options/elasticsearch.yaml
+++ b/config/options/elasticsearch.yaml
@@ -1,7 +1,7 @@
 ---
 options:
   - name: elasticsearch-version
-    value: 9.1.10
+    value: 7.10
   - name: elasticsearch-plugins
     value:
   - name: elasticsearch-port

--- a/config/options/mongodb.yaml
+++ b/config/options/mongodb.yaml
@@ -1,7 +1,7 @@
 ---
 options:
   - name: mongodb-version
-    value: null
+    value: 8.0.0
   - name: mongodb-replica-set
     value:
   - name: mongodb-port

--- a/config/options/mysql.yaml
+++ b/config/options/mysql.yaml
@@ -1,7 +1,7 @@
 ---
 options:
   - name: mysql-version
-    value: 9.6
+    value: 8.0
   - name: mysql-distribution
     value:
   - name: mysql-auto-start

--- a/config/options/redis.yaml
+++ b/config/options/redis.yaml
@@ -1,7 +1,7 @@
 ---
 options:
   - name: redis-version
-    value: 9.0.1
+    value: 8.2
   - name: redis-port
     value:
   - name: redis-tls-port

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -39,7 +39,7 @@
 | Ruby | rspec-core | 3.13.6 | MIT | BDD for Ruby | <https://rspec.info> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | rspec-expectations | 3.13.5 | MIT | rspec-expectations provides a simple, readable API to express expected outcomes of a code example. | <https://rspec.info> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | rspec-mocks | 3.13.7 | MIT | RSpec's 'test double' framework, with support for stubbing and mocking | <https://rspec.info> | 2026-01-26 | Low | Dependency | Dependency |
-| Ruby | rspec-support | 3.13.6 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-01-26 | Low | Dependency | Dependency |
+| Ruby | rspec-support | 3.13.7 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | rubocop | 1.84.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-01-26 | Low | Ruby linter | Most popular gem on rubygems |
 | Ruby | rubocop-ast | 1.49.0 | MIT | RuboCop's Node and NodePattern classes. | <https://www.rubocop.org/> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | rubocop-capybara | 2.22.1 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-01-26 | Low | Ruby linter | Most popular gem |


### PR DESCRIPTION
## Summary

This PR updates default version numbers for various services and fixes regex escaping issues in the gitignore configuration file.

**Key changes:**
- Update rspec-support gem from 3.13.6 to 3.13.7 and Bundler from 4.0.4 to 4.0.5
- Fix regex escaping for Django and Flask package detection patterns in gitignore.yaml (escape `[` as `\\[`)
- Update Elasticsearch default version from 9.1.10 to 7.10
- Update MongoDB default version from null to 8.0.0
- Update MySQL default version from 9.6 to 8.0
- Update Redis default version from 9.0.1 to 8.2

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration changes that update default values; existing tests cover the configuration loading
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
