### PR TITLE
Rename SwiftLint rule redundant_self_in_closure to redundant_self

### DIFF
--- a/config/linters/.swiftlint.yml
+++ b/config/linters/.swiftlint.yml
@@ -122,7 +122,7 @@ opt_in_rules:
   # - raw_value_for_camel_cased_codable_enum
   - reduce_into
   - redundant_nil_coalescing
-  - redundant_self_in_closure
+  - redundant_self
   - redundant_type_annotation
   # - required_deinit
   - required_enum_case


### PR DESCRIPTION
## Summary
- Rename deprecated SwiftLint rule `redundant_self_in_closure` to `redundant_self`
- The old rule name was renamed in a recent SwiftLint version and will be removed in a future release

## Test plan
- [ ] Verify SwiftLint runs without deprecation warnings