### PR TITLE
Update Go to 1.25.7, Python to 3.14.3, Bundler to 4.0.6, and markdownlint config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webmock (>= 3.18.0)
 
 BUNDLED WITH
-  4.0.5
+  4.0.6

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -7,7 +7,7 @@ go:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.25.6
+      value: 1.25.7
     - name: go-version-file
       value:
     - name: go-check-latest
@@ -215,7 +215,7 @@ proto:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.25.6
+      value: 1.25.7
     - name: go-version-file
       value:
     - name: go-check-latest
@@ -251,7 +251,7 @@ python:
     - .python-version
   setup_options:
     - name: python-version
-      value: 3.14.2
+      value: 3.14.3
     - name: python-version-file
       value:
     - name: python-cache

--- a/config/linters/.markdownlint.yml
+++ b/config/linters/.markdownlint.yml
@@ -4,3 +4,6 @@ line-length: false
 no-duplicate-heading: false
 single-h1: false
 tables: false
+no-inline-html:
+  allowed_elements:
+    - br


### PR DESCRIPTION
# Summary

Update default language versions and linter configuration to their latest releases.

**Key changes:**
- Update Go version from 1.25.6 to 1.25.7 for both `go` and `proto` language configurations in `config/languages.yaml`
- Update Python version from 3.14.2 to 3.14.3 in `config/languages.yaml`
- Update Bundler from 4.0.5 to 4.0.6 in `Gemfile.lock`
- Add `no-inline-html` rule to `config/linters/.markdownlint.yml` allowing `<br>` elements

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bumps and linter config change do not require new tests
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
