### PR TITLE
Extract HTTParty calls to GitHubAPIClient (#270)

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -7,6 +7,7 @@ require 'httparty'
 require 'json'
 require 'psych'
 
+require_relative 'github_api_client'
 require_relative 'options'
 require_relative 'status'
 require_relative 'workflow/workflow'
@@ -909,28 +910,15 @@ module GHB
       puts('Configuring repository settings...')
       repository = Dir.pwd.split('/').last
       repo_url = "https://api.github.com/repos/#{@options.organization}/#{repository}"
-
-      headers =
-        {
-          headers:
-            {
-              Authorization: "token #{github_token}",
-              Accept: 'application/vnd.github.v3+json'
-            }
-        }
+      github_client = GitHubAPIClient.new(github_token)
 
       # Get repository info to check visibility
-      response = HTTParty.get(repo_url, headers)
-      raise("Cannot get repository info: #{response.message}") unless response.code == 200
-
+      response = github_client.get(repo_url)
       repo_info = JSON.parse(response.body)
       is_private = repo_info['private'] == true
 
       # Get current branch protection to preserve settings (404 means no protection configured yet)
-      response = HTTParty.get("#{repo_url}/branches/master/protection", headers)
-
-      raise("Cannot get branch protection: #{response.message}") unless [200, 404].include?(response.code)
-
+      response = github_client.get("#{repo_url}/branches/master/protection", expected_codes: [200, 404])
       protection_exists = response.code == 200
       current_protection = protection_exists ? JSON.parse(response.body) : {}
 
@@ -941,7 +929,7 @@ module GHB
       code_scanning_checks = []
 
       # Check for CodeQL default setup
-      codeql_response = HTTParty.get("#{repo_url}/code-scanning/default-setup", headers)
+      codeql_response = github_client.get("#{repo_url}/code-scanning/default-setup", expected_codes: nil)
 
       if codeql_response.code == 200
         codeql_setup = JSON.parse(codeql_response.body)
@@ -1040,29 +1028,23 @@ module GHB
         required_conversation_resolution: true
       }
 
-      response = HTTParty.put(
-        "#{repo_url}/branches/master/protection",
-        headers.merge(body: branch_protection.to_json)
-      )
-      raise("Cannot set branch protection: #{response.message}") unless response.code == 200
+      github_client.put("#{repo_url}/branches/master/protection", body: branch_protection)
 
       # Enable required signatures (separate endpoint)
       puts('    Enabling required signatures...')
-      response = HTTParty.post(
+      github_client.post(
         "#{repo_url}/branches/master/protection/required_signatures",
-        headers.merge(headers: headers[:headers].merge(Accept: 'application/vnd.github.zzzax-preview+json'))
+        headers: { Accept: 'application/vnd.github.zzzax-preview+json' },
+        expected_codes: [200, 204]
       )
-      raise("Cannot enable required signatures: #{response.message}") unless [200, 204].include?(response.code)
 
       # Enable vulnerability alerts
       puts('    Enabling vulnerability alerts...')
-      response = HTTParty.put("#{repo_url}/vulnerability-alerts", headers)
-      raise("Cannot enable vulnerability alerts: #{response.message}") unless [200, 204].include?(response.code)
+      github_client.put("#{repo_url}/vulnerability-alerts", expected_codes: [200, 204])
 
       # Enable automated security fixes
       puts('    Enabling automated security fixes...')
-      response = HTTParty.put("#{repo_url}/automated-security-fixes", headers)
-      raise("Cannot enable automated security fixes: #{response.message}") unless [200, 204].include?(response.code)
+      github_client.put("#{repo_url}/automated-security-fixes", expected_codes: [200, 204])
 
       # Configure repository settings
       puts('    Configuring repository options...')
@@ -1075,8 +1057,7 @@ module GHB
         delete_branch_on_merge: true
       }
 
-      response = HTTParty.patch(repo_url, headers.merge(body: repo_settings.to_json))
-      raise("Cannot configure repository settings: #{response.message}") unless response.code == 200
+      github_client.patch(repo_url, body: repo_settings)
 
       # Advanced Security features - disable for private repos (GHAS incurs charges)
       if is_private
@@ -1091,7 +1072,7 @@ module GHB
           }
         }
 
-        response = HTTParty.patch(repo_url, headers.merge(body: security_settings.to_json))
+        response = github_client.patch(repo_url, body: security_settings, expected_codes: nil)
 
         if response.code == 200
           puts('        Secret scanning disabled')
@@ -1112,8 +1093,7 @@ module GHB
           }
         }
 
-        response = HTTParty.patch(repo_url, headers.merge(body: security_settings.to_json))
-        raise("Cannot enable Advanced Security features: #{response.message}") unless response.code == 200
+        github_client.patch(repo_url, body: security_settings)
 
         puts('        Secret scanning enabled')
         puts('        Secret scanning push protection enabled')
@@ -1129,9 +1109,10 @@ module GHB
           state: 'not-configured'
         }
 
-        response = HTTParty.patch(
+        response = github_client.patch(
           "#{repo_url}/code-scanning/default-setup",
-          headers.merge(body: code_scanning_config.to_json)
+          body: code_scanning_config,
+          expected_codes: nil
         )
 
         puts('        CodeQL default setup disabled') if [200, 202].include?(response.code)
@@ -1139,9 +1120,7 @@ module GHB
         puts('    Enabling CodeQL default setup...')
 
         # First check current status
-        response = HTTParty.get("#{repo_url}/code-scanning/default-setup", headers)
-        raise("Cannot get CodeQL default setup status: #{response.message}") unless response.code == 200
-
+        response = github_client.get("#{repo_url}/code-scanning/default-setup")
         current_setup = JSON.parse(response.body)
 
         if current_setup['state'] == 'configured'
@@ -1152,11 +1131,11 @@ module GHB
             query_suite: 'default'
           }
 
-          response = HTTParty.patch(
+          github_client.patch(
             "#{repo_url}/code-scanning/default-setup",
-            headers.merge(body: code_scanning_config.to_json)
+            body: code_scanning_config,
+            expected_codes: [200, 202]
           )
-          raise("Cannot enable CodeQL default setup: #{response.message}") unless [200, 202].include?(response.code)
 
           puts('        CodeQL default setup enabled')
         end

--- a/lib/ghb/github_api_client.rb
+++ b/lib/ghb/github_api_client.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'httparty'
+require 'json'
+
+module GHB
+  # Centralized GitHub API client with shared headers, retry logic, and error handling.
+  # Extracts duplicated HTTParty calls from Application#check_repository_settings.
+  class GitHubAPIClient
+    MAX_RETRIES = 3
+    RETRYABLE_ERRORS = [Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET].freeze
+
+    private_constant :MAX_RETRIES
+    private_constant :RETRYABLE_ERRORS
+
+    def initialize(token)
+      @headers = {
+        Authorization: "token #{token}",
+        Accept: 'application/vnd.github.v3+json'
+      }
+    end
+
+    def get(url, expected_codes: [200])
+      execute(:get, url, expected_codes: expected_codes)
+    end
+
+    def put(url, body: nil, expected_codes: [200])
+      execute(:put, url, body: body, expected_codes: expected_codes)
+    end
+
+    def post(url, body: nil, headers: {}, expected_codes: [200])
+      execute(:post, url, body: body, headers: headers, expected_codes: expected_codes)
+    end
+
+    def patch(url, body: nil, expected_codes: [200])
+      execute(:patch, url, body: body, expected_codes: expected_codes)
+    end
+
+    private
+
+    def execute(method, url, body: nil, headers: {}, expected_codes: [200])
+      options = { headers: @headers.merge(headers) }
+      options[:body] = body.to_json if body
+
+      response = with_retries { HTTParty.public_send(method, url, options) }
+
+      raise("HTTP #{method.upcase} #{url} failed: #{response.message} (#{response.code})") if expected_codes && !expected_codes.include?(response.code)
+
+      response
+    end
+
+    def with_retries
+      retries = 0
+
+      loop do
+        response = yield
+        return response if retries >= MAX_RETRIES || response.code < 500
+
+        retries += 1
+        sleep(retries)
+      rescue *RETRYABLE_ERRORS
+        retries += 1
+        raise if retries > MAX_RETRIES
+
+        sleep(retries)
+      end
+    end
+  end
+end

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+RSpec.describe(GHB::GitHubAPIClient) do
+  let(:token)           { 'test-token-123'                         }
+  let(:client)          { described_class.new(token)               }
+  let(:base_url)        { 'https://api.github.com/repos/org/repo'  }
+  let(:default_headers) do
+    {
+      Authorization: 'token test-token-123',
+      Accept: 'application/vnd.github.v3+json'
+    }
+  end
+
+  before do
+    allow(client).to(receive(:sleep))
+  end
+
+  describe '#get' do
+    it 'sends GET request with auth headers' do
+      stub_request(:get, base_url)
+        .with(headers: default_headers)
+        .to_return(status: 200, body: '{"ok":true}')
+
+      response = client.get(base_url)
+      expect(response.code).to(eq(200))
+    end
+
+    it 'raises on unexpected status code' do
+      stub_request(:get, base_url)
+        .to_return(status: 404, body: '{"message":"Not Found"}')
+
+      expect { client.get(base_url) }
+        .to(raise_error(RuntimeError, /HTTP GET.*failed.*404/))
+    end
+
+    it 'accepts custom expected_codes' do
+      stub_request(:get, base_url)
+        .to_return(status: 404, body: '{}')
+
+      response = client.get(base_url, expected_codes: [200, 404])
+      expect(response.code).to(eq(404))
+    end
+
+    it 'skips validation when expected_codes is nil' do
+      stub_request(:get, base_url)
+        .to_return(status: 403, body: '{"message":"Forbidden"}')
+
+      response = client.get(base_url, expected_codes: nil)
+      expect(response.code).to(eq(403))
+    end
+  end
+
+  describe '#put' do
+    it 'sends PUT request with auth headers' do
+      stub_request(:put, base_url)
+        .with(headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.put(base_url)
+      expect(response.code).to(eq(200))
+    end
+
+    it 'serializes body as JSON' do
+      stub_request(:put, base_url)
+        .with(body: '{"key":"value"}', headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.put(base_url, body: { key: 'value' })
+      expect(response.code).to(eq(200))
+    end
+
+    it 'accepts custom expected_codes' do
+      stub_request(:put, base_url)
+        .to_return(status: 204, body: '')
+
+      response = client.put(base_url, expected_codes: [200, 204])
+      expect(response.code).to(eq(204))
+    end
+
+    it 'raises on unexpected status code' do
+      stub_request(:put, base_url)
+        .to_return(status: 422, body: '{"message":"Unprocessable"}')
+
+      expect { client.put(base_url) }
+        .to(raise_error(RuntimeError, /HTTP PUT.*failed.*422/))
+    end
+  end
+
+  describe '#post' do
+    it 'sends POST request with auth headers' do
+      stub_request(:post, base_url)
+        .with(headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.post(base_url)
+      expect(response.code).to(eq(200))
+    end
+
+    it 'serializes body as JSON' do
+      stub_request(:post, base_url)
+        .with(body: '{"data":"test"}', headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.post(base_url, body: { data: 'test' })
+      expect(response.code).to(eq(200))
+    end
+
+    it 'merges custom headers with defaults' do # rubocop:disable RSpec/ExampleLength
+      custom_accept = 'application/vnd.github.zzzax-preview+json'
+
+      stub_request(:post, base_url)
+        .with(headers: default_headers.merge(Accept: custom_accept))
+        .to_return(status: 200, body: '{}')
+
+      response = client.post(base_url, headers: { Accept: custom_accept })
+      expect(response.code).to(eq(200))
+    end
+
+    it 'accepts custom expected_codes' do
+      stub_request(:post, base_url)
+        .to_return(status: 204, body: '')
+
+      response = client.post(base_url, expected_codes: [200, 204])
+      expect(response.code).to(eq(204))
+    end
+  end
+
+  describe '#patch' do
+    it 'sends PATCH request with auth headers' do
+      stub_request(:patch, base_url)
+        .with(headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.patch(base_url)
+      expect(response.code).to(eq(200))
+    end
+
+    it 'serializes body as JSON' do
+      stub_request(:patch, base_url)
+        .with(body: '{"setting":true}', headers: default_headers)
+        .to_return(status: 200, body: '{}')
+
+      response = client.patch(base_url, body: { setting: true })
+      expect(response.code).to(eq(200))
+    end
+
+    it 'raises on unexpected status code' do
+      stub_request(:patch, base_url)
+        .to_return(status: 500, body: '{"message":"Internal Server Error"}')
+
+      expect { client.patch(base_url) }
+        .to(raise_error(RuntimeError, /HTTP PATCH.*failed.*500/))
+    end
+
+    it 'skips validation when expected_codes is nil' do
+      stub_request(:patch, base_url)
+        .to_return(status: 422, body: '{}')
+
+      response = client.patch(base_url, expected_codes: nil)
+      expect(response.code).to(eq(422))
+    end
+  end
+
+  describe 'retry logic' do
+    it 'retries on 5xx responses' do # rubocop:disable RSpec/ExampleLength
+      stub_request(:get, base_url)
+        .to_return(status: 503, body: '{}')
+        .then.to_return(status: 503, body: '{}')
+        .then.to_return(status: 200, body: '{"ok":true}')
+
+      response = client.get(base_url)
+      expect(response.code).to(eq(200))
+    end
+
+    it 'raises after exhausting retries on 5xx' do
+      stub_request(:get, base_url)
+        .to_return(status: 503, body: '{}')
+
+      expect { client.get(base_url) }
+        .to(raise_error(RuntimeError, /HTTP GET.*failed.*503/))
+    end
+
+    it 'retries on Net::OpenTimeout' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      call_count = 0
+
+      allow(HTTParty).to(receive(:get)) do
+        call_count += 1
+        raise(Net::OpenTimeout, 'execution expired') if call_count < 3
+
+        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+      end
+
+      response = client.get(base_url)
+      expect(response.code).to(eq(200))
+      expect(call_count).to(eq(3))
+    end
+
+    it 'retries on Net::ReadTimeout' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      call_count = 0
+
+      allow(HTTParty).to(receive(:get)) do
+        call_count += 1
+        raise(Net::ReadTimeout, 'execution expired') if call_count < 2
+
+        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+      end
+
+      response = client.get(base_url)
+      expect(response.code).to(eq(200))
+      expect(call_count).to(eq(2))
+    end
+
+    it 'retries on Errno::ECONNRESET' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      call_count = 0
+
+      allow(HTTParty).to(receive(:get)) do
+        call_count += 1
+        raise(Errno::ECONNRESET, 'Connection reset by peer') if call_count < 2
+
+        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+      end
+
+      response = client.get(base_url)
+      expect(response.code).to(eq(200))
+      expect(call_count).to(eq(2))
+    end
+
+    it 'raises after exhausting retries on network error' do
+      allow(HTTParty).to(receive(:get).and_raise(Net::OpenTimeout, 'execution expired'))
+
+      expect { client.get(base_url) }
+        .to(raise_error(Net::OpenTimeout))
+    end
+
+    it 'does not retry on 4xx responses' do # rubocop:disable RSpec/MultipleExpectations
+      stub_request(:get, base_url)
+        .to_return(status: 422, body: '{"message":"Unprocessable"}')
+
+      expect { client.get(base_url) }
+        .to(raise_error(RuntimeError, /HTTP GET.*failed.*422/))
+
+      expect(a_request(:get, base_url)).to(have_been_made.once)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'webmock/rspec'
 # Load the application
 require_relative '../lib/ghb'
 require_relative '../lib/ghb/application'
+require_relative '../lib/ghb/github_api_client'
 require_relative '../lib/ghb/options'
 require_relative '../lib/ghb/status'
 require_relative '../lib/ghb/workflow/job'


### PR DESCRIPTION
## Summary

Centralizes 13 duplicated GitHub API HTTParty calls from `check_repository_settings` into a new `GHB::GitHubAPIClient` class with shared auth headers, retry logic, and error handling.

**Key changes:**
- Add `lib/ghb/github_api_client.rb` with `get`, `put`, `post`, `patch` methods, shared auth headers, `expected_codes` validation, and retry logic (up to 3 retries with linear backoff for 5xx responses and network errors)
- Refactor `lib/ghb/application.rb` to replace 13 inline HTTParty calls and the duplicated headers block in `check_repository_settings` with `GitHubAPIClient` calls
- Add `spec/ghb/git_hub_api_client_spec.rb` with 23 WebMock-based tests covering all HTTP methods, header merging, body serialization, expected_codes validation, and retry behavior
- Update `spec/spec_helper.rb` to require the new client module

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified