### PR TITLE
Fix #269: Reduce nesting in detect_gitignore_templates

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -1234,52 +1234,55 @@ module GHB
     def detect_gitignore_templates(config)
       templates = Set.new
 
-      # Add always-enabled templates
-      config[:always_enabled]&.each do |template|
-        templates.add(template)
-      end
+      config[:always_enabled]&.each { |template| templates.add(template) }
 
-      # Exclude common dependency/build folders from search - pure Ruby approach (SEC-002)
-      dependency_excludes = %w[node_modules vendor .git .hg .svn venv .venv env __pycache__ .pytest_cache .bundle target build dist out Pods Carthage .build DerivedData packages .nuget .npm .yarn .pnpm bower_components jspm_packages]
-      excluded_paths = dependency_excludes + @submodules
+      excluded_paths = build_gitignore_excluded_paths
 
-      # Detect templates based on file extensions, specific files, and packages
       config[:extension_detection]&.each do |template_name, detection_config|
-        detected = false
-
-        # Check for file extensions - pure Ruby (SEC-002)
-        detection_config[:extensions]&.each do |ext|
-          break if detected
-
-          pattern = Regexp.new("\\.#{Regexp.escape(ext)}$")
-          matches = find_files_matching('.', pattern, excluded_paths, max_depth: 5)
-          detected = matches.any?
-        end
-
-        # Check for specific files
-        detection_config[:files]&.each do |file|
-          break if detected
-
-          detected = File.exist?(file)
-        end
-
-        # Check for packages in package manager files - pure Ruby regex (SEC-002)
-        detection_config[:packages]&.each do |pm_file, packages|
-          break if detected
-          next unless File.exist?(pm_file.to_s)
-
-          file_content = File.read(pm_file.to_s)
-          packages.each do |pkg|
-            break if detected
-
-            detected = file_content.match?(Regexp.new(pkg))
-          end
-        end
-
-        templates.add(template_name.to_s) if detected
+        templates.add(template_name.to_s) if template_detected?(detection_config, excluded_paths)
       end
 
       templates.to_a.sort
+    end
+
+    # Exclude common dependency/build folders from search - pure Ruby approach (SEC-002)
+    def build_gitignore_excluded_paths
+      dependency_excludes = %w[node_modules vendor .git .hg .svn venv .venv env __pycache__ .pytest_cache .bundle target build dist out Pods Carthage .build DerivedData packages .nuget .npm .yarn .pnpm bower_components jspm_packages]
+      dependency_excludes + @submodules
+    end
+
+    def template_detected?(detection_config, excluded_paths)
+      extension_detected?(detection_config[:extensions], excluded_paths) ||
+        file_detected?(detection_config[:files]) ||
+        package_detected?(detection_config[:packages])
+    end
+
+    # Check for file extensions - pure Ruby (SEC-002)
+    def extension_detected?(extensions, excluded_paths)
+      return false if extensions.nil?
+
+      extensions.any? do |ext|
+        pattern = Regexp.new("\\.#{Regexp.escape(ext)}$")
+        find_files_matching('.', pattern, excluded_paths, max_depth: 5).any?
+      end
+    end
+
+    def file_detected?(files)
+      return false if files.nil?
+
+      files.any? { |file| File.exist?(file) }
+    end
+
+    # Check for packages in package manager files - pure Ruby regex (SEC-002)
+    def package_detected?(packages)
+      return false if packages.nil?
+
+      packages.any? do |pm_file, pkg_patterns|
+        next false unless File.exist?(pm_file.to_s)
+
+        file_content = File.read(pm_file.to_s)
+        pkg_patterns.any? { |pkg| file_content.match?(Regexp.new(pkg)) }
+      end
     end
 
     def detect_custom_patterns(config)


### PR DESCRIPTION
# Summary

Refactor the `detect_gitignore_templates` method in `lib/ghb/application.rb` to reduce nesting and cyclomatic complexity by extracting focused helper methods and replacing manual `break if detected` loops with idiomatic Ruby `any?` calls.

**Key changes:**
- Extract `build_gitignore_excluded_paths` to build the dependency exclusion list
- Extract `template_detected?` to orchestrate the three detection strategies
- Extract `extension_detected?`, `file_detected?`, and `package_detected?` as focused single-responsibility helpers
- Replace manual boolean flag tracking (`detected = false` / `break if detected`) with `any?` short-circuit evaluation

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Pure refactoring with no behavior change; existing test suite passes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified