### PR TITLE
Add private methods section heading to architecture docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,9 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `initialize(argv)`: Sets up option parser with defaults
 - `parse`: Parses command-line arguments
 - `args_comment`: Generates comment header for persisting arguments
+
+**Private Methods:**
+
 - `args_from_file(file)`: Reads arguments from existing build file
 
 **Attributes:**


### PR DESCRIPTION
## Summary

Add a "Private Methods" section heading to the `ArgsParser` class documentation in `docs/architecture.md` to improve readability and organization.

**Key changes:**
- Add "Private Methods:" heading before `args_from_file(file)` in the ArgsParser section of `docs/architecture.md`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change, no functional impact
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
