### PR TITLE
Disable code owner reviews and update PHP and parallel gem versions

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -302,7 +302,7 @@
   "parallel": {
     "language": "Ruby",
     "package": "parallel",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "license": "MIT",
     "description": "Run any kind of code in parallel processes",
     "website": "https://github.com/grosser/parallel",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
     optparse (0.8.1)
-    parallel (2.0.0)
+    parallel (2.0.1)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -253,7 +253,7 @@ php:
     - .php-version
   setup_options:
     - name: php-version
-      value: 8.5.4
+      value: 8.5.5
     - name: php-version-file
       value:
     - name: php-extensions

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -27,7 +27,7 @@
 | Ruby | minitest | 6.0.3 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | multi_xml | 0.8.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-01-26 | Low | Command line argument parser | Ruby standard library gem maintained by the Ruby core team |
-| Ruby | parallel | 2.0.0 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-01-26 | Low | Dependency | Dependency |
+| Ruby | parallel | 2.0.1 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | parser | 3.3.11.1 | MIT | A Ruby parser written in pure Ruby. | <https://github.com/whitequark/parser> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | prism | 1.9.0 | MIT | Prism Ruby parser | <https://github.com/ruby/prism> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | psych | 5.3.1 | MIT | Psych is a YAML parser and emitter | <https://github.com/ruby/psych> | 2026-01-26 | Low | Yaml parser | Ruby standard library gem maintained by the Ruby core team |

--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -139,7 +139,7 @@ module GHB
         enforce_admins: false,
         required_pull_request_reviews: {
           dismiss_stale_reviews: true,
-          require_code_owner_reviews: true,
+          require_code_owner_reviews: false,
           require_last_push_approval: true,
           required_approving_review_count: 1,
           dismissal_restrictions: {

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe(GHB::AutoMergeManager) do
       expect(merge_step).not_to(be_nil)
       expect(merge_step.if).to(eq("steps.check.outputs.is_owner == 'true'"))
       expect(merge_step.run).to(eq('gh pr merge --auto --squash "$PR"'))
+      expect(merge_step.env[:GH_TOKEN]).to(eq('${{secrets.GITHUB_TOKEN}}'))
     end
   end
 end

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
               enforce_admins: false,
               required_pull_request_reviews: hash_including(
                 dismiss_stale_reviews: true,
-                require_code_owner_reviews: true,
+                require_code_owner_reviews: false,
                 require_last_push_approval: true,
                 required_approving_review_count: 1
               ),


### PR DESCRIPTION
## Summary

Disable the `require_code_owner_reviews` branch protection setting to support the auto-merge workflow for code owners, and bump PHP version and the parallel gem.

**Key changes:**
- Set `require_code_owner_reviews` to `false` in branch protection configuration and updated the corresponding spec
- Added test assertion to verify the auto-merge workflow merge step uses `GITHUB_TOKEN` via the `GH_TOKEN` env var
- Bumped PHP version from 8.5.4 to 8.5.5 in `config/languages.yaml`
- Updated `parallel` gem from 2.0.0 to 2.0.1 in `Gemfile.lock`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
