### PR TITLE
Update default Python version from 3.14.3 to 3.14.4

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -339,7 +339,7 @@ python:
     - .python-version
   setup_options:
     - name: python-version
-      value: 3.14.3
+      value: 3.14.4
     - name: python-version-file
       value:
     - name: python-cache


### PR DESCRIPTION
# Summary

Update the default Python setup version in the languages configuration from 3.14.3 to 3.14.4.

**Key changes:**
- Bump `python-version` from 3.14.3 to 3.14.4 in `config/languages.yaml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bump only, no logic change
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
