### PR TITLE
Update Xcode version to 26.4.1 and add ktlint preserve_config

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -315,7 +315,7 @@ proto:
     - name: go-architecture
       value:
     - name: xcode-version
-      value: 26.4
+      value: 26.4.1
   dependencies:
     - dependency_file: go.mod
       install_dirs:

--- a/config/linters.yaml
+++ b/config/linters.yaml
@@ -97,6 +97,7 @@ ktlint:
   condition: "github.event_name == 'pull_request'"
   uses: cloud-officer/ci-actions/linters/ktlint
   config: ".editorconfig"
+  preserve_config: true
   path: "."
   pattern: ".*\\.(kt|kts)$"
 markdownlint:


### PR DESCRIPTION
# Summary

Update the Xcode version for the proto language configuration and enable config preservation for the ktlint linter.

**Key changes:**
- Update `xcode-version` from `26.4` to `26.4.1` in `config/languages.yaml`
- Add `preserve_config: true` to the ktlint linter configuration in `config/linters.yaml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration-only changes that do not require new tests
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
