### PR TITLE
Update minitest gem from 6.0.4 to 6.0.5

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -266,7 +266,7 @@
   "minitest": {
     "language": "Ruby",
     "package": "minitest",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "license": "MIT",
     "description": "minitest provides a complete suite of testing facilities supporting",
     "website": "https://minite.st/",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     lint_roller (1.1.0)
     logger (1.7.0)
     mini_mime (1.1.5)
-    minitest (6.0.4)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     multi_xml (0.8.1)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -24,7 +24,7 @@
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | mini_mime | 1.1.5 | MIT | A minimal mime type library | <https://github.com/discourse/mini_mime> | 2026-01-26 | Low | Dependency | Dependency |
-| Ruby | minitest | 6.0.4 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-01-26 | Low | Dependency | Dependency |
+| Ruby | minitest | 6.0.5 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | multi_xml | 0.8.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-01-26 | Low | Command line argument parser | Ruby standard library gem maintained by the Ruby core team |
 | Ruby | parallel | 2.0.1 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-01-26 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Updates the minitest gem dependency to the latest patch release to stay current with upstream bug fixes and improvements.

**Key changes:**

- Bump `minitest` from 6.0.4 to 6.0.5 in `Gemfile.lock`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
