### PR TITLE
Remove enable auto-merge step from code-owner workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -77,10 +77,3 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         PR: "${{github.event.pull_request.number}}"
-    - name: Enable auto-merge
-      shell: bash
-      if: steps.check.outputs.is_owner == 'true'
-      run: gh pr merge --auto --squash "$PR"
-      env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-        PR: "${{github.event.pull_request.number}}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -336,14 +336,14 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 ### GHB::AutoMergeManager
 
-**Purpose:** Manages auto-merge workflow generation for code owners, enabling automatic squash-merge of pull requests authored by CODEOWNERS.
+**Purpose:** Manages auto-merge workflow generation for code owners, providing automatic approval of pull requests authored by CODEOWNERS.
 
 **Location:** `lib/ghb/auto_merge_manager.rb`
 
 **Key Components:**
 
 - `initialize(auto_merge_workflow:)`: Accepts auto-merge workflow object
-- `save`: Configures the auto-merge workflow with CODEOWNERS detection, auto-approval, and writes `.github/workflows/auto-merge.yml`
+- `save`: Configures the auto-merge workflow with CODEOWNERS detection and auto-approval, and writes `.github/workflows/auto-merge.yml`
 
 ### GHB::DependabotManager
 

--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -106,18 +106,6 @@ module GHB
           )
           do_run('gh pr review --approve "$PR"')
         end
-
-        do_step('Enable auto-merge') do
-          do_if("steps.check.outputs.is_owner == 'true'")
-          do_shell('bash')
-          do_env(
-            {
-              GH_TOKEN: '${{secrets.GITHUB_TOKEN}}',
-              PR: '${{github.event.pull_request.number}}'
-            }
-          )
-          do_run('gh pr merge --auto --squash "$PR"')
-        end
       end
 
       @auto_merge_workflow.write('.github/workflows/auto-merge.yml')

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -95,15 +95,12 @@ RSpec.describe(GHB::AutoMergeManager) do
       expect(approve_step.run).to(eq('gh pr review --approve "$PR"'))
     end
 
-    it 'includes an enable auto-merge step' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+    it 'does not include an enable auto-merge step' do
       manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
       manager.save
 
       merge_step = auto_merge_workflow.jobs[:enable_automerge].steps.find { |s| s.name == 'Enable auto-merge' }
-      expect(merge_step).not_to(be_nil)
-      expect(merge_step.if).to(eq("steps.check.outputs.is_owner == 'true'"))
-      expect(merge_step.run).to(eq('gh pr merge --auto --squash "$PR"'))
-      expect(merge_step.env[:GH_TOKEN]).to(eq('${{secrets.GITHUB_TOKEN}}'))
+      expect(merge_step).to(be_nil)
     end
   end
 end


### PR DESCRIPTION
## Summary

Removes the step that enables auto-merge on pull requests authored by CODEOWNERS. The workflow continues to detect code-owner-authored PRs and auto-approve them, but no longer calls `gh pr merge --auto --squash`, so merging now requires an explicit human action.

**Key changes:**

- Removed the `Enable auto-merge` step from `AutoMergeManager` so the generated workflow only performs the approval.
- Regenerated `.github/workflows/auto-merge.yml` to match the updated generator output.
- Updated the `auto_merge_manager_spec.rb` test to assert the auto-merge step is no longer generated.
- Updated `docs/architecture.md` to describe the manager as approval-only.

Note: the `allow_auto_merge: true` repository setting in `RepositoryConfigurator` is intentionally left in place.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified