### PR TITLE
Honor --excluded_folders in gitignore template detection

### DIFF
--- a/lib/ghb/gitignore_manager.rb
+++ b/lib/ghb/gitignore_manager.rb
@@ -131,9 +131,9 @@ module GHB
       templates.to_a.sort
     end
 
-    # Build excluded paths from languages.yaml config + submodules - pure Ruby approach (SEC-002)
+    # Build excluded paths from languages.yaml config + submodules + --excluded_folders (SEC-002)
     def build_gitignore_excluded_paths
-      excluded_dirs_from_config + @submodules
+      excluded_dirs_from_config + @submodules + @options.excluded_folders
     end
 
     def template_detected?(detection_config, excluded_paths)

--- a/spec/ghb/gitignore_manager_spec.rb
+++ b/spec/ghb/gitignore_manager_spec.rb
@@ -196,18 +196,18 @@ RSpec.describe(GHB::GitignoreManager) do
   end
 
   describe '#build_gitignore_excluded_paths (private)' do
-    it 'includes excluded_folders from --excluded_folders option' do
+    it 'includes excluded_folders from --excluded_folders option' do # rubocop:disable RSpec/ExampleLength
       options = instance_double(
         GHB::Options,
         skip_gitignore: false,
         gitignore_config_file: 'config/gitignore.yaml',
         languages_config_file: 'config/languages.yaml',
-        excluded_folders: ['var', 'tmp']
+        excluded_folders: %w[var tmp]
       )
       mgr = described_class.new(options: options, submodules: ['pnp-scripts'], file_cache: {})
       allow(mgr).to(receive(:excluded_dirs_from_config).and_return(['.git']))
 
-      expect(mgr.__send__(:build_gitignore_excluded_paths)).to(eq(['.git', 'pnp-scripts', 'var', 'tmp']))
+      expect(mgr.__send__(:build_gitignore_excluded_paths)).to(eq(%w[.git pnp-scripts var tmp]))
     end
   end
 

--- a/spec/ghb/gitignore_manager_spec.rb
+++ b/spec/ghb/gitignore_manager_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe(GHB::GitignoreManager) do
       GHB::Options,
       skip_gitignore: false,
       gitignore_config_file: 'config/gitignore.yaml',
-      languages_config_file: 'config/languages.yaml'
+      languages_config_file: 'config/languages.yaml',
+      excluded_folders: []
     )
   end
   let(:manager) { described_class.new(options: mock_options, submodules: submodules, file_cache: file_cache) }
@@ -191,6 +192,22 @@ RSpec.describe(GHB::GitignoreManager) do
       result = manager.__send__(:detect_gitignore_templates, config)
 
       expect(result).to(include('ruby'))
+    end
+  end
+
+  describe '#build_gitignore_excluded_paths (private)' do
+    it 'includes excluded_folders from --excluded_folders option' do
+      options = instance_double(
+        GHB::Options,
+        skip_gitignore: false,
+        gitignore_config_file: 'config/gitignore.yaml',
+        languages_config_file: 'config/languages.yaml',
+        excluded_folders: ['var', 'tmp']
+      )
+      mgr = described_class.new(options: options, submodules: ['pnp-scripts'], file_cache: {})
+      allow(mgr).to(receive(:excluded_dirs_from_config).and_return(['.git']))
+
+      expect(mgr.__send__(:build_gitignore_excluded_paths)).to(eq(['.git', 'pnp-scripts', 'var', 'tmp']))
     end
   end
 


### PR DESCRIPTION
## Summary
- `GitignoreManager#build_gitignore_excluded_paths` previously combined only `excluded_dirs_from_config + submodules`, ignoring `@options.excluded_folders`. This caused false-positive template detection — e.g. pnp-api's `var/cache/api/prod/App_ApiKernelProdContainer.php.meta` (Symfony container metadata) tripped the Unity template (which detects `meta` extension) on every dep-update PR.
- `linter_job_builder.rb` and `language_job_builder.rb` already honor the flag; this brings `gitignore_manager` into the same pattern with a one-line change.
- Added a unit test covering the exclusion behavior; updated existing mock_options stub to expose `excluded_folders: []`.

## Test plan
- [x] `bundle exec rspec spec/ghb/gitignore_manager_spec.rb` — 25/25 pass
- [x] `bundle exec rspec` — 306/306 pass, 94.09% line coverage / 84.54% branch coverage
- [ ] After merge, run repos.sh against pnp-api with `--excluded_folders ...,var` and verify Unity is no longer added to the regenerated .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)