### PR TITLE
Update language versions, redis pin, and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -533,3 +533,4 @@ $RECYCLE.BIN/
 # END AI Assistants
 
 .rspec_status
+docs/code-review.md

--- a/.soup.json
+++ b/.soup.json
@@ -278,7 +278,7 @@
   "multi_xml": {
     "language": "Ruby",
     "package": "multi_xml",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "license": "MIT",
     "description": "Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.",
     "website": "https://github.com/sferik/multi_xml",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    multi_xml (0.9.0)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     optparse (0.8.1)
     parallel (2.1.0)

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -57,7 +57,7 @@ go:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.26.2
+      value: 1.26.3
     - name: go-version-file
       value:
     - name: go-check-latest
@@ -93,7 +93,7 @@ js:
     - .nvmrc
   setup_options:
     - name: node-version
-      value: 25.9.0
+      value: 26.1.0
     - name: node-always-auth
       value:
     - name: node-version-file
@@ -253,7 +253,7 @@ php:
     - .php-version
   setup_options:
     - name: php-version
-      value: 8.5.5
+      value: 8.5.6
     - name: php-version-file
       value:
     - name: php-extensions
@@ -301,7 +301,7 @@ proto:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.26.2
+      value: 1.26.3
     - name: go-version-file
       value:
     - name: go-check-latest

--- a/config/options/redis.yaml
+++ b/config/options/redis.yaml
@@ -11,7 +11,7 @@
 options:
   # Redis server version
   - name: redis-version
-    value: latest
+    value: 9.0
   # Port number (default: 6379)
   - name: redis-port
     value:

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -25,7 +25,7 @@
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | mini_mime | 1.1.5 | MIT | A minimal mime type library | <https://github.com/discourse/mini_mime> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | minitest | 6.0.6 | MIT | minitest provides a complete suite of testing facilities supporting | <https://minite.st/> | 2026-01-26 | Low | Dependency | Dependency |
-| Ruby | multi_xml | 0.9.0 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-01-26 | Low | Dependency | Dependency |
+| Ruby | multi_xml | 0.9.1 | MIT | Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML. | <https://github.com/sferik/multi_xml> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | optparse | 0.8.1 | Ruby | OptionParser is a class for command-line option analysis | <https://github.com/ruby/optparse> | 2026-01-26 | Low | Command line argument parser | Ruby standard library gem maintained by the Ruby core team |
 | Ruby | parallel | 2.1.0 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-01-26 | Low | Dependency | Dependency |
 | Ruby | parser | 3.3.11.1 | MIT | A Ruby parser written in pure Ruby. | <https://github.com/whitequark/parser> | 2026-01-26 | Low | Dependency | Dependency |


### PR DESCRIPTION
## Summary

Routine dependency and configuration refresh. Bumps default language toolchain versions (Go, Node, PHP), pins Redis to a stable major instead of `latest`, refreshes `multi_xml` in the lockfile, and ignores the locally generated code-review report.

**Key changes:**

- Bump Go default to `1.26.3` (in both `go` and `proto` sections of `config/languages.yaml`)
- Bump Node default to `26.1.0` in `config/languages.yaml`
- Bump PHP default to `8.5.6` in `config/languages.yaml`
- Pin Redis option default from `latest` to `9.0` in `config/options/redis.yaml`
- Update `multi_xml` to `0.9.1` in `Gemfile.lock`
- Ignore `docs/code-review.md` in `.gitignore`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration/version bumps only, covered by existing CI.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified