### PR TITLE
Use bot PAT for auto-merge approvals and require code owner reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                        @ydesgagn
+*                        @Cloud-Officer/Maintainers
 
 # build/deploy related files
 
-.github/                 @ydesgagn
-.gitignore               @ydesgagn
-.markdownlint-cli2.yaml  @ydesgagn
-.rubocop.yml             @ydesgagn
-.ruby-version            @ydesgagn
-.shellcheckrc            @ydesgagn
-.yamllint.yml            @ydesgagn
-bin/                     @ydesgagn
-lib/                     @ydesgagn
+.github/                 @Cloud-Officer/maintainers
+.gitignore               @Cloud-Officer/maintainers
+.markdownlint-cli2.yaml  @Cloud-Officer/maintainers
+.rubocop.yml             @Cloud-Officer/maintainers
+.ruby-version            @Cloud-Officer/maintainers
+.shellcheckrc            @Cloud-Officer/maintainers
+.yamllint.yml            @Cloud-Officer/maintainers
+bin/                     @Cloud-Officer/maintainers
+lib/                     @Cloud-Officer/maintainers

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -75,5 +75,5 @@ jobs:
       if: steps.check.outputs.is_owner == 'true'
       run: gh pr review --approve "$PR"
       env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
         PR: "${{github.event.pull_request.number}}"

--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -100,7 +100,7 @@ module GHB
           do_shell('bash')
           do_env(
             {
-              GH_TOKEN: '${{secrets.GITHUB_TOKEN}}',
+              GH_TOKEN: '${{secrets.GH_BOT_PAT}}',
               PR: '${{github.event.pull_request.number}}'
             }
           )

--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -139,7 +139,7 @@ module GHB
         enforce_admins: false,
         required_pull_request_reviews: {
           dismiss_stale_reviews: true,
-          require_code_owner_reviews: false,
+          require_code_owner_reviews: true,
           require_last_push_approval: true,
           required_approving_review_count: 1,
           dismissal_restrictions: {

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe(GHB::AutoMergeManager) do
       expect(approve_step).not_to(be_nil)
       expect(approve_step.if).to(eq("steps.check.outputs.is_owner == 'true'"))
       expect(approve_step.run).to(eq('gh pr review --approve "$PR"'))
+      expect(approve_step.env[:GH_TOKEN]).to(eq('${{secrets.GH_BOT_PAT}}'))
     end
 
     it 'does not include an enable auto-merge step' do

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
               enforce_admins: false,
               required_pull_request_reviews: hash_including(
                 dismiss_stale_reviews: true,
-                require_code_owner_reviews: false,
+                require_code_owner_reviews: true,
                 require_last_push_approval: true,
                 required_approving_review_count: 1
               ),


### PR DESCRIPTION
## Summary

Switches the auto-merge approval workflow to use a bot Personal Access Token instead of the default `GITHUB_TOKEN`, transfers ownership from an individual to the `Cloud-Officer/maintainers` team in `CODEOWNERS`, and enables `require_code_owner_reviews` on protected branches so code owner approval is enforced.

**Key changes:**

- Update `.github/CODEOWNERS` to assign ownership to `@Cloud-Officer/maintainers` (team) instead of `@ydesgagn`.
- Update `.github/workflows/auto-merge.yml` to authenticate the approve step with `secrets.GH_BOT_PAT` instead of `secrets.GITHUB_TOKEN`.
- Update `lib/ghb/auto_merge_manager.rb` to generate the auto-merge workflow with the new `GH_BOT_PAT` secret.
- Update `lib/ghb/repository_configurator.rb` to set `require_code_owner_reviews: true` on protected branches.
- Update `spec/ghb/auto_merge_manager_spec.rb` to assert the approve step uses `secrets.GH_BOT_PAT`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
