### PR TITLE
Update Xcode version to 26.5

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -315,7 +315,7 @@ proto:
     - name: go-architecture
       value:
     - name: xcode-version
-      value: 26.4.1
+      value: 26.5
   dependencies:
     - dependency_file: go.mod
       install_dirs:


### PR DESCRIPTION
## Summary

Bumps the pinned `xcode-version` for the `proto` language entry in `config/languages.yaml` from `26.4.1` to `26.5` to keep iOS/macOS toolchain in sync with the latest Xcode release.

**Key changes:**

- `config/languages.yaml`: update `proto.xcode-version` from `26.4.1` to `26.5`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration version bump only; no code paths changed.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified