### PR TITLE
Pin macOS runner to macos-26 and add --sync_required_status_checks flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-latest
+        - macos-26
         - ubuntu-latest
     steps:
     - name: Setup

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ options
         --skip_license_check         Skip license check
         --skip_repository_settings   Skip check of repository settings
         --skip_slack                 Skip slack
-        --no_strict_version_check    Do not auto-update when VERSION options
-                                     do not match recommended defaults
+        --no_strict_version_check    Do not auto-update when VERSION options do not match recommended defaults
+        --sync_required_status_checks
+                                     On branch protection check mismatch, overwrite remote check list with the expected one instead of erroring (useful when renaming jobs/matrix values)
     -h, --help                       Show this message
 ```
 

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -330,7 +330,7 @@ proto:
       dependabot_ecosystem: gomod
   unit_test_framework_name: Protoc
   unit_test_framework_default: protoc
-  runs-on: macos-latest
+  runs-on: macos-26
 python:
   short_name: python
   long_name: Python
@@ -376,7 +376,7 @@ swift:
   short_name: swift
   long_name: Swift
   file_extension: swift
-  runs-on: macos-latest
+  runs-on: macos-26
   dependencies:
     - dependency_file: Gemfile
       install_dirs:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,11 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `skip_semgrep`: Skip semgrep linter
 - `skip_slack`: Skip Slack notification job
 - `strict_version_check`: Auto-update version files and env vars to recommended values on mismatch (default: true)
+- `sync_required_status_checks`: On branch protection check mismatch, overwrite the remote check list with the expected one instead of erroring (useful when renaming jobs or matrix values)
+
+**Constants:**
+
+- `EPHEMERAL_FLAGS`: One-shot flags (e.g. `--sync_required_status_checks`) that are stripped from `original_argv` so they are not persisted to the generated workflow header
 
 ### GHB::Status
 
@@ -553,7 +558,7 @@ All dependencies are managed via Bundler with versions locked in `Gemfile.lock`.
 4. Detects Vercel integration (Next.js) and CodeQL languages, filtering redundant entries
 5. Discovers Xcode Cloud checks dynamically when `ci_scripts` directory exists: extracts from existing branch protection or from commit statuses on the default branch for new repos
 6. Collects required status checks from generated workflow jobs
-7. Validates existing checks match expected checks (only for existing protection)
+7. Validates existing checks match expected checks (only for existing protection); on mismatch, raises an error unless `--sync_required_status_checks` is set, in which case the remote check list is rebuilt from `expected_checks` while preserving `app_id` values for existing entries (so integration-specific configurations such as Xcode Cloud checks are not clobbered)
 8. Preserves existing dismissal restrictions and bypass allowances
 9. Configures branch protection with required status checks, code-owner review enforcement (`require_code_owner_reviews: true`), pull request reviews, signed commits, and conversation resolution
 10. Configures repository options: enables vulnerability alerts and automated security fixes, disables wiki and projects, configures merge strategies, and enables delete branch on merge

--- a/lib/ghb.rb
+++ b/lib/ghb.rb
@@ -15,7 +15,7 @@ module GHB
   OPTIONS_REDIS_CONFIG_FILE = 'config/options/redis.yaml'
   OPTIONS_ELASTICSEARCH_CONFIG_FILE = 'config/options/elasticsearch.yaml'
   DEFAULT_UBUNTU_VERSION = 'ubuntu-latest'
-  DEFAULT_MACOS_VERSION = 'macos-latest'
+  DEFAULT_MACOS_VERSION = 'macos-26'
   DEFAULT_JOB_TIMEOUT_MINUTES = 30
 
   private_constant :CI_ACTIONS_VERSION

--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -8,12 +8,15 @@ require_relative 'status'
 module GHB
   class Options
     ARGS_COMMENT_PREFIX = '# github-build'
+    # Flags that are one-shot in nature and must not be persisted to the generated workflow header.
+    EPHEMERAL_FLAGS = %w[--sync_required_status_checks].freeze
     private_constant :ARGS_COMMENT_PREFIX
+    private_constant :EPHEMERAL_FLAGS
 
     def initialize(argv = [])
       @application_name = Dir.pwd.split('/').last.split('-').last
       @argv = argv.empty? ? args_from_file(DEFAULT_BUILD_FILE) : argv.dup
-      @original_argv = @argv.dup
+      @original_argv = @argv.reject { |arg| EPHEMERAL_FLAGS.include?(arg) }
       @build_file = DEFAULT_BUILD_FILE
       @excluded_folders = []
       @force_codedeploy_setup = false
@@ -38,11 +41,12 @@ module GHB
       @get_ignored_folders = false
       @skip_slack = false
       @strict_version_check = true
+      @sync_required_status_checks = false
 
       setup_parser
     end
 
-    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :mono_repo, :only_dependabot, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_dependabot, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check
+    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :mono_repo, :only_dependabot, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_dependabot, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check, :sync_required_status_checks
 
     def parse
       @parser.parse!(@argv)
@@ -170,6 +174,10 @@ module GHB
 
       @parser.on('', '--no_strict_version_check', 'Do not auto-update when VERSION options do not match recommended defaults') do
         @strict_version_check = false
+      end
+
+      @parser.on('', '--sync_required_status_checks', 'On branch protection check mismatch, overwrite remote check list with the expected one instead of erroring (useful when renaming jobs/matrix values)') do
+        @sync_required_status_checks = true
       end
 
       @parser.on_tail('-h', '--help', 'Show this message') do

--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -107,11 +107,15 @@ module GHB
             extra_checks.each { |check| puts("          + #{check}") }
           end
 
-          raise('Error: branch protection checks mismatch!')
+          raise('Error: branch protection checks mismatch!') unless @options.sync_required_status_checks
+
+          puts('        --sync_required_status_checks set: overwriting remote check list with expected')
+          sync_required_status_checks = true
         end
       else
         puts('        No existing branch protection, will create with expected checks')
       end
+      sync_required_status_checks ||= false
 
       # Preserve existing dismissal restrictions or use empty defaults
       dismissal_users = current_protection.dig('required_pull_request_reviews', 'dismissal_restrictions', 'users')&.map { |u| u['login'] } || []
@@ -121,10 +125,18 @@ module GHB
       bypass_users = current_protection.dig('required_pull_request_reviews', 'bypass_pull_request_allowances', 'users')&.map { |u| u['login'] } || []
       bypass_teams = current_protection.dig('required_pull_request_reviews', 'bypass_pull_request_allowances', 'teams')&.map { |t| t['slug'] } || []
 
-      # Use existing checks if protection exists, otherwise build from expected checks
+      # Use existing checks if protection exists, otherwise build from expected checks.
+      # When syncing, rebuild from expected_checks but preserve app_id from existing entries
+      # to avoid clobbering integration-specific check configurations (e.g. Xcode Cloud).
       status_checks =
-        if protection_exists
+        if protection_exists && !sync_required_status_checks
           current_protection.dig('required_status_checks', 'checks') || []
+        elsif protection_exists && sync_required_status_checks
+          existing_app_ids =
+            (current_protection.dig('required_status_checks', 'checks') || []).to_h do |check|
+              [check['context'], check['app_id']]
+            end
+          expected_checks.map { |check| { context: check, app_id: existing_app_ids.fetch(check, nil) } }
         else
           expected_checks.map { |check| { context: check, app_id: nil } }
         end

--- a/spec/ghb/options_spec.rb
+++ b/spec/ghb/options_spec.rb
@@ -261,6 +261,13 @@ RSpec.describe(GHB::Options) do
 
       expect(comment).to(eq("# github-build --organization TestOrg --skip_slack\n"))
     end
+
+    it 'omits ephemeral flags from the persisted comment' do
+      options = described_class.new(['--organization', 'TestOrg', '--sync_required_status_checks', '--skip_slack']).parse
+
+      expect(options.sync_required_status_checks).to(be(true))
+      expect(options.args_comment).to(eq("# github-build --organization TestOrg --skip_slack\n"))
+    end
   end
 
   describe 'args_from_file (private)' do

--- a/spec/ghb/options_spec.rb
+++ b/spec/ghb/options_spec.rb
@@ -265,8 +265,13 @@ RSpec.describe(GHB::Options) do
     it 'omits ephemeral flags from the persisted comment' do
       options = described_class.new(['--organization', 'TestOrg', '--sync_required_status_checks', '--skip_slack']).parse
 
-      expect(options.sync_required_status_checks).to(be(true))
       expect(options.args_comment).to(eq("# github-build --organization TestOrg --skip_slack\n"))
+    end
+
+    it 'still parses ephemeral flags into option state' do
+      options = described_class.new(['--sync_required_status_checks']).parse
+
+      expect(options.sync_required_status_checks).to(be(true))
     end
   end
 

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -432,8 +432,8 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
       let(:current_protection) do
         {
           required_status_checks: {
-            contexts: ['Build', 'StaleCheck'],
-            checks: [{ 'context' => 'Build', 'app_id' => 42 }, { 'context' => 'StaleCheck', 'app_id' => nil }]
+            contexts: %w[Build StaleCheck],
+            checks: [{ context: 'Build', app_id: 42 }, { context: 'StaleCheck', app_id: nil }]
           },
           required_pull_request_reviews: {}
         }
@@ -459,31 +459,29 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
         instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
       end
 
+      let(:expected_checks_payload) do
+        hash_including(
+          required_status_checks: {
+            strict: false,
+            checks: [
+              { context: 'Build', app_id: 42 },
+              { context: 'Lint', app_id: nil }
+            ]
+          }
+        )
+      end
+
       before do
         allow(github_client).to(receive(:get).with(repo_url).and_return(repo_info_response))
         allow(github_client).to(receive(:get).with("#{repo_url}/branches/#{default_branch}/protection", expected_codes: [200, 404]).and_return(protection_response))
         allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup", expected_codes: nil).and_return(codeql_default_setup_response))
         allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup").and_return(codeql_get_response))
-        allow(github_client).to(receive(:put).and_return(empty_response))
-        allow(github_client).to(receive(:post).and_return(empty_response))
-        allow(github_client).to(receive(:patch).and_return(empty_response))
+        allow(github_client).to(receive_messages(put: empty_response, post: empty_response, patch: empty_response))
+        configurator.configure
       end
 
-      it 'does not raise and rewrites branch protection with expected checks while preserving app_ids' do
-        expect { configurator.configure }.not_to(raise_error)
-
-        expect(github_client).to(have_received(:put).with(
-          "#{repo_url}/branches/#{default_branch}/protection",
-          body: hash_including(
-            required_status_checks: {
-              strict: false,
-              checks: [
-                { context: 'Build', app_id: 42 },
-                { context: 'Lint', app_id: nil }
-              ]
-            }
-          )
-        ))
+      it 'rewrites branch protection with expected checks while preserving app_ids' do
+        expect(github_client).to(have_received(:put).with("#{repo_url}/branches/#{default_branch}/protection", body: expected_checks_payload))
       end
     end
 

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
   let(:required_status_checks) { %w[Build Lint]                                               }
 
   let(:mock_options) do
-    instance_double(GHB::Options, skip_repository_settings: false, organization: organization)
+    instance_double(GHB::Options, skip_repository_settings: false, organization: organization, sync_required_status_checks: false)
   end
 
   let(:github_client) do
@@ -421,6 +421,69 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
       it 'raises an error when expected checks are missing from branch protection' do
         expect { configurator.configure }
           .to(raise_error(RuntimeError, 'Error: branch protection checks mismatch!'))
+      end
+    end
+
+    context 'when branch protection has mismatching checks and sync_required_status_checks is true' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:mock_options) do
+        instance_double(GHB::Options, skip_repository_settings: false, organization: organization, sync_required_status_checks: true)
+      end
+
+      let(:current_protection) do
+        {
+          required_status_checks: {
+            contexts: ['Build', 'StaleCheck'],
+            checks: [{ 'context' => 'Build', 'app_id' => 42 }, { 'context' => 'StaleCheck', 'app_id' => nil }]
+          },
+          required_pull_request_reviews: {}
+        }
+      end
+
+      let(:repo_info_response) do
+        instance_double(HTTParty::Response, code: 200, body: { private: false }.to_json)
+      end
+
+      let(:protection_response) do
+        instance_double(HTTParty::Response, code: 200, body: current_protection.to_json)
+      end
+
+      let(:codeql_default_setup_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:empty_response) do
+        instance_double(HTTParty::Response, code: 200, body: '{}')
+      end
+
+      let(:codeql_get_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      before do
+        allow(github_client).to(receive(:get).with(repo_url).and_return(repo_info_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/branches/#{default_branch}/protection", expected_codes: [200, 404]).and_return(protection_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup", expected_codes: nil).and_return(codeql_default_setup_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup").and_return(codeql_get_response))
+        allow(github_client).to(receive(:put).and_return(empty_response))
+        allow(github_client).to(receive(:post).and_return(empty_response))
+        allow(github_client).to(receive(:patch).and_return(empty_response))
+      end
+
+      it 'does not raise and rewrites branch protection with expected checks while preserving app_ids' do
+        expect { configurator.configure }.not_to(raise_error)
+
+        expect(github_client).to(have_received(:put).with(
+          "#{repo_url}/branches/#{default_branch}/protection",
+          body: hash_including(
+            required_status_checks: {
+              strict: false,
+              checks: [
+                { context: 'Build', app_id: 42 },
+                { context: 'Lint', app_id: nil }
+              ]
+            }
+          )
+        ))
       end
     end
 


### PR DESCRIPTION
## Summary

Pins the macOS GitHub Actions runner from the `macos-latest` rolling tag to the explicit `macos-26` image so CI behavior remains stable across runner upgrades, and introduces a new opt-in `--sync_required_status_checks` flag that lets `github-build` repair branch-protection check lists when job or matrix names change (instead of failing with a mismatch error).

**Key changes:**

- Replace `macos-latest` with `macos-26` in the default constant (`lib/ghb.rb`), the workflow matrix (`.github/workflows/build.yml`), and the `proto`/`swift` language entries (`config/languages.yaml`)
- Add `--sync_required_status_checks` CLI option in `lib/ghb/options.rb`, along with a new `EPHEMERAL_FLAGS` constant that strips one-shot flags from `original_argv` so they are not persisted to the generated workflow header
- In `lib/ghb/repository_configurator.rb`, treat a branch-protection check mismatch as recoverable when the new flag is set: rebuild the remote check list from `expected_checks` while preserving each existing entry's `app_id` (so integration-specific configurations such as Xcode Cloud checks are not clobbered)
- Update `README.md` help block and `docs/architecture.md` to document the new option, the `EPHEMERAL_FLAGS` constant, and the updated branch-protection sync behavior

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified