### PR TITLE
Update actions/checkout to v6 in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: "${{github.event.pull_request.base.sha}}"
     - name: Check if PR author is a code owner

--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -31,7 +31,7 @@ module GHB
         do_runs_on(DEFAULT_UBUNTU_VERSION)
 
         do_step('Checkout') do
-          do_uses('actions/checkout@v4')
+          do_uses('actions/checkout@v6')
           do_with(
             {
               ref: '${{github.event.pull_request.base.sha}}'

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe(GHB::AutoMergeManager) do
 
       checkout_step = auto_merge_workflow.jobs[:enable_automerge].steps.find { |s| s.name == 'Checkout' }
       expect(checkout_step).not_to(be_nil)
-      expect(checkout_step.uses).to(eq('actions/checkout@v4'))
+      expect(checkout_step.uses).to(eq('actions/checkout@v6'))
       expect(checkout_step.with[:ref]).to(eq('${{github.event.pull_request.base.sha}}'))
     end
 


### PR DESCRIPTION
## Summary

Upgrades the `actions/checkout` GitHub Action from v4 to v6 in the auto-merge workflow generated by `GHB::AutoMergeManager`. This keeps the auto-merge workflow on the latest major version of the checkout action and aligns with current GitHub recommendations.

**Key changes:**

- Bump `actions/checkout` from `v4` to `v6` in `.github/workflows/auto-merge.yml`
- Bump `actions/checkout` from `v4` to `v6` in the auto-merge workflow generator (`lib/ghb/auto_merge_manager.rb`)
- Update the corresponding spec expectation in `spec/ghb/auto_merge_manager_spec.rb`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified