### PR TITLE
Scope ${GITHUB_*} → ${{github.*}} rewrite to non-run: contexts

### DIFF
--- a/lib/ghb/workflow/workflow.rb
+++ b/lib/ghb/workflow/workflow.rb
@@ -116,11 +116,11 @@ module GHB
       FileUtils.mkdir_p(File.dirname(file))
       content = header + to_h.deep_stringify_keys.to_yaml({ line_width: -1 })
 
-      # Convert old-style ${GITHUB_*} patterns to new-style ${{github.*}}
-      content.gsub!(/\$\{GITHUB_([A-Z_]+)\}/) do |_match|
-        var_name = ::Regexp.last_match(1).downcase
-        "${{github.#{var_name}}}"
-      end
+      # NOTE: do NOT rewrite ${GITHUB_*} -> ${{github.*}}. Shell `run:` blocks
+      # legitimately use the ${GITHUB_*} env-var form (set by the runner), and
+      # ${{github.*}} inside a shell expression is opaque to shellcheck and
+      # trips SC2193. Authors writing if:/env:/with: should use ${{github.*}}
+      # directly; we won't auto-translate one form into the other.
 
       # Convert secrets.GITHUB_TOKEN to secrets.GH_PAT for higher rate limits
       content.gsub!('${{secrets.GITHUB_TOKEN}}', '${{secrets.GH_PAT}}') unless file.include?('auto-merge')

--- a/lib/ghb/workflow/workflow.rb
+++ b/lib/ghb/workflow/workflow.rb
@@ -8,6 +8,9 @@ require_relative 'job'
 
 module GHB
   class Workflow
+    GITHUB_ENV_VAR_REGEX = /\$\{GITHUB_([A-Z_]+)\}/
+    private_constant :GITHUB_ENV_VAR_REGEX
+
     def initialize(name)
       @name = name
       @run_name = nil
@@ -114,13 +117,8 @@ module GHB
 
     def write(file, header: '')
       FileUtils.mkdir_p(File.dirname(file))
-      content = header + to_h.deep_stringify_keys.to_yaml({ line_width: -1 })
-
-      # NOTE: do NOT rewrite ${GITHUB_*} -> ${{github.*}}. Shell `run:` blocks
-      # legitimately use the ${GITHUB_*} env-var form (set by the runner), and
-      # ${{github.*}} inside a shell expression is opaque to shellcheck and
-      # trips SC2193. Authors writing if:/env:/with: should use ${{github.*}}
-      # directly; we won't auto-translate one form into the other.
+      data = rewrite_github_refs(to_h.deep_stringify_keys)
+      content = header + data.to_yaml({ line_width: -1 })
 
       # Convert secrets.GITHUB_TOKEN to secrets.GH_PAT for higher rate limits
       content.gsub!('${{secrets.GITHUB_TOKEN}}', '${{secrets.GH_PAT}}') unless file.include?('auto-merge')
@@ -139,6 +137,26 @@ module GHB
       hash[:concurrency] = @concurrency unless @concurrency.empty?
       hash[:jobs] = @jobs.transform_values(&:to_h)
       hash
+    end
+
+    private
+
+    # Rewrite ${GITHUB_*} -> ${{github.*}} in YAML values, but skip shell `run:`
+    # bodies - there ${GITHUB_*} is the runner-exported env-var form and
+    # ${{github.*}} is opaque to shellcheck (SC2193).
+    def rewrite_github_refs(node)
+      case node
+      when Hash
+        node.each_with_object({}) do |(key, value), acc|
+          acc[key] = key.to_s == 'run' ? value : rewrite_github_refs(value)
+        end
+      when Array
+        node.map { |item| rewrite_github_refs(item) }
+      when String
+        node.gsub(GITHUB_ENV_VAR_REGEX) { "${{github.#{::Regexp.last_match(1).downcase}}}" }
+      else
+        node
+      end
     end
   end
 end

--- a/spec/ghb/workflow/workflow_spec.rb
+++ b/spec/ghb/workflow/workflow_spec.rb
@@ -295,6 +295,21 @@ RSpec.describe(GHB::Workflow) do # rubocop:disable RSpec/SpecFilePathFormat
       end
     end
 
+    it 'preserves ${GITHUB_*} inside shell run: blocks' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      workflow.do_job(:build) do
+        do_runs_on('ubuntu-latest')
+        do_step('echo sha') do
+          do_run('echo "$GITHUB_SHA ${GITHUB_REF}"')
+        end
+      end
+      workflow.write(temp_file)
+
+      expect(File).to(have_received(:write)) do |_, content|
+        expect(content).to(include('${GITHUB_REF}'))
+        expect(content).not_to(include('${{github.ref}}'))
+      end
+    end
+
     it 'converts secrets.GITHUB_TOKEN to secrets.GH_PAT' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       workflow.do_env({ TOKEN: '${{secrets.GITHUB_TOKEN}}' })
       workflow.write(temp_file)


### PR DESCRIPTION
## Summary

The workflow writer was running a blanket regex substitution across the entire rendered YAML, rewriting every `${GITHUB_*}` into the GitHub expression form `${{github.*}}`. That rewrite is correct for `env:`, `if:`, `with:`, `concurrency:`, `run-name:`, etc. (where `${GITHUB_*}` is *not* shell-expanded and the canonical expression form is required), but wrong inside shell `run:` blocks: there `${GITHUB_*}` is the env-var syntax the runner actually exports, while `${{github.*}}` is opaque to shellcheck and trips SC2193.

Instead of removing the translation outright (the first attempt — which broke `env:` values that have no other way to interpolate `github.*` context), this scopes it: we walk the parsed YAML tree before serialization and skip values whose enclosing key is `run`. Every other context still gets the canonical `${{github.*}}` form.

**Key changes:**

- Replace the blanket-string `gsub!` in `Workflow#write` with a recursive `rewrite_github_refs` helper that walks the hash/array structure and applies the regex only to non-`run:` string values
- Extract the regex to a `private_constant` (`GITHUB_ENV_VAR_REGEX`)
- Update the existing `${GITHUB_*}` → `${{github.*}}` spec (env: context, still translated) and add a new spec verifying `${GITHUB_*}` inside step `run:` bodies is preserved verbatim

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified