### PR TITLE
Make hand-maintained smoke.yml jobs required status checks

### DIFF
--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'psych'
 require 'uri'
 
 require_relative 'github_api_client'
@@ -49,6 +50,18 @@ module GHB
     def configure_branch_protection(github_client, repo_url, current_protection, protection_exists)
       # Add Vercel check if Next.js project
       @required_status_checks << 'Vercel' if File.exist?('package.json') && File.read('package.json').include?('"next"')
+
+      # Add checks for a hand-maintained .github/workflows/smoke.yml. That
+      # workflow is intentionally NOT generated (e.g. ci-actions smoke-tests
+      # its own composite actions), so its jobs are absent from
+      # @required_status_checks; discover them here so they stay required
+      # across regenerations. Job names are read dynamically so renaming a
+      # smoke job needs no generator change.
+      smoke_workflow = '.github/workflows/smoke.yml'
+      if File.exist?(smoke_workflow)
+        smoke_jobs = (Psych.safe_load(File.read(smoke_workflow)) || {})['jobs'] || {}
+        smoke_jobs.each { |job_id, job| @required_status_checks << ((job && job['name']) || job_id.to_s) }
+      end
 
       # Check for CodeQL default setup
       codeql_response = github_client.get("#{repo_url}/code-scanning/default-setup", expected_codes: nil)

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
     allow(Dir).to(receive(:pwd).and_return("/home/user/#{repository}"))
     allow(GHB::GitHubAPIClient).to(receive(:new).with(github_token).and_return(github_client))
     allow(File).to(receive(:exist?).with('package.json').and_return(false))
+    allow(File).to(receive(:exist?).with('.github/workflows/smoke.yml').and_return(false))
     allow(Dir).to(receive(:exist?).with('ci_scripts').and_return(false))
   end
 
@@ -592,6 +593,83 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
             body: hash_including(
               required_status_checks: hash_including(
                 checks: [{ context: 'Build', app_id: nil }, { context: 'Lint', app_id: nil }]
+              )
+            )
+          )
+        )
+      end
+    end
+
+    context 'when .github/workflows/smoke.yml exists (smoke-test detection)' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:repo_info_response) do
+        instance_double(HTTParty::Response, code: 200, body: { private: false }.to_json)
+      end
+
+      let(:protection_response) do
+        instance_double(HTTParty::Response, code: 404, body: '{"message":"Not Found"}')
+      end
+
+      let(:codeql_default_setup_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:codeql_get_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:ok_response) do
+        instance_double(HTTParty::Response, code: 200, body: '{}')
+      end
+
+      let(:accepted_response) do
+        instance_double(HTTParty::Response, code: 202, body: '{}')
+      end
+
+      let(:smoke_yaml) do
+        <<~YAML
+          ---
+          name: Smoke
+          'on': [push]
+          jobs:
+            action-contracts:
+              name: Action contracts (all 28)
+            linters-smoke:
+              name: Linter actions (disabled path)
+            variables-smoke:
+        YAML
+      end
+
+      before do
+        allow(File).to(receive(:exist?).with('.github/workflows/smoke.yml').and_return(true))
+        allow(File).to(receive(:read).with('.github/workflows/smoke.yml').and_return(smoke_yaml))
+
+        allow(github_client).to(receive(:get).with(repo_url).and_return(repo_info_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/branches/#{default_branch}/protection", expected_codes: [200, 404]).and_return(protection_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup", expected_codes: nil).and_return(codeql_default_setup_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/branches/#{default_branch}/protection", body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:post).with("#{repo_url}/branches/#{default_branch}/protection/required_signatures", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/vulnerability-alerts", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/automated-security-fixes", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:patch).with(repo_url, body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup").and_return(codeql_get_response))
+        allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: anything, expected_codes: [200, 202]).and_return(accepted_response))
+      end
+
+      it 'adds each smoke job (by name, falling back to job id) to the expected checks' do # rubocop:disable RSpec/ExampleLength
+        configurator.configure
+
+        expect(github_client).to(
+          have_received(:put).with(
+            "#{repo_url}/branches/#{default_branch}/protection",
+            body: hash_including(
+              required_status_checks: hash_including(
+                checks: [
+                  { context: 'Build', app_id: nil },
+                  { context: 'Lint', app_id: nil },
+                  { context: 'Action contracts (all 28)', app_id: nil },
+                  { context: 'Linter actions (disabled path)', app_id: nil },
+                  { context: 'variables-smoke', app_id: nil }
+                ]
               )
             )
           )


### PR DESCRIPTION
## Summary

Branch protection is generator-managed: `collect_required_status_checks` only walks the generated `build.yml` jobs, so jobs from a hand-maintained `.github/workflows/smoke.yml` are never in the expected list. The result is that adding the smoke checks to branch protection by hand makes the next `github-build` run fail on a checks mismatch (or, with `--sync_required_status_checks`, strips them again).

This teaches the generator to discover those jobs, mirroring the existing non-workflow check detection (the `Vercel` line right above the new code).

Key changes:

- `lib/ghb/repository_configurator.rb`: after the Vercel detection, if `.github/workflows/smoke.yml` exists, parse it with `Psych` and append each job to `@required_status_checks` using the job `name` (falling back to the job id when a job has no `name`). Added `require 'psych'`. Job names are read dynamically so renaming a smoke job needs no generator change.
- `spec/ghb/repository_configurator_spec.rb`: default-stub `File.exist?('.github/workflows/smoke.yml')` to `false` in the shared `before` (so existing examples are unaffected), plus a new context asserting the three discovered checks (two by `name`, one falling back to the job id) are appended after `Build`/`Lint`.

After this merges, run `github-build ... --sync_required_status_checks` against ci-actions once so the new contexts (`Action contracts (all 28)`, `Linter actions (disabled path)`, `Variables action`) are pushed into `master` branch protection; thereafter every regeneration keeps them required.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified