### PR TITLE
Improve GitHub API error diagnostics, CLI error handling, and spec isolation

### DIFF
--- a/lib/ghb.rb
+++ b/lib/ghb.rb
@@ -4,6 +4,9 @@ module GHB
   # Custom error for configuration validation failures
   class ConfigError < StandardError; end
 
+  # Custom error for failed GitHub REST API calls (carries the response body for diagnosis)
+  class GitHubAPIError < StandardError; end
+
   CI_ACTIONS_VERSION = 'v2'
   DEFAULT_BUILD_FILE = '.github/workflows/build.yml'
   DEFAULT_GITIGNORE_CONFIG_FILE = 'config/gitignore.yaml'

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -131,8 +131,8 @@ module GHB
 
     def configure_options(argv)
       Options.new(argv).parse
-    rescue OptionParser::InvalidOption => e
-      puts("Error: #{e}")
+    rescue OptionParser::ParseError => e
+      warn("Error: #{e}")
       exit(Status::ERROR_EXIT_CODE)
     end
 

--- a/lib/ghb/github_api_client.rb
+++ b/lib/ghb/github_api_client.rb
@@ -3,6 +3,8 @@
 require 'httparty'
 require 'json'
 
+require_relative '../ghb'
+
 module GHB
   # Centralized GitHub API client with shared headers, retry logic, and error handling.
   # Extracts duplicated HTTParty calls from Application#check_repository_settings.
@@ -44,7 +46,10 @@ module GHB
 
       response = with_retries { HTTParty.public_send(method, url, options) }
 
-      raise("HTTP #{method.upcase} #{url} failed: #{response.message} (#{response.code})") if expected_codes && !expected_codes.include?(response.code)
+      if expected_codes && !expected_codes.include?(response.code)
+        body = response.body.to_s.strip[0, 1000]
+        raise(GitHubAPIError, "HTTP #{method.upcase} #{url} failed: #{response.code} #{response.message}#{" — #{body}" unless body.to_s.empty?}")
+      end
 
       response
     end

--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -71,6 +71,8 @@ module GHB
       args_string = first_line.sub(ARGS_COMMENT_PREFIX, '').strip
       require('shellwords')
       Shellwords.split(args_string)
+    rescue ArgumentError => e
+      raise(ConfigError, "Malformed github-build args in #{file}: #{e.message}")
     end
 
     def setup_parser
@@ -87,7 +89,7 @@ module GHB
       end
 
       @parser.on('', '--excluded_folders excluded_folders', 'Comma separated list of folders to ignore') do |excluded_folders|
-        @excluded_folders = excluded_folders.split(',')
+        @excluded_folders = excluded_folders.split(',').reject(&:empty?)
       end
 
       @parser.on('', '--force_codedeploy_setup', 'Force executing the setup step in CodeDeploy even if not technically required') do

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         .to_return(status: 404, body: '{"message":"Not Found"}')
 
       expect { client.get(base_url) }
-        .to(raise_error(RuntimeError, /HTTP GET.*failed.*404/))
+        .to(raise_error(GHB::GitHubAPIError, /HTTP GET.*failed.*404/))
     end
 
     it 'accepts custom expected_codes' do
@@ -82,7 +82,23 @@ RSpec.describe(GHB::GitHubAPIClient) do
         .to_return(status: 422, body: '{"message":"Unprocessable"}')
 
       expect { client.put(base_url) }
-        .to(raise_error(RuntimeError, /HTTP PUT.*failed.*422/))
+        .to(raise_error(GHB::GitHubAPIError, /HTTP PUT.*failed.*422/))
+    end
+
+    it 'includes the response body in the error for diagnosis' do
+      stub_request(:put, base_url)
+        .to_return(status: 422, body: '{"message":"Invalid request","errors":[{"field":"required_status_checks"}]}')
+
+      expect { client.put(base_url) }
+        .to(raise_error(GHB::GitHubAPIError, /Invalid request.*required_status_checks/))
+    end
+
+    it 'truncates an oversized response body to 1000 characters' do
+      stub_request(:put, base_url)
+        .to_return(status: 422, body: "#{'x' * 5000}END")
+
+      expect { client.put(base_url) }
+        .to(raise_error(GHB::GitHubAPIError, /— x{1000}\z/))
     end
   end
 
@@ -149,7 +165,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         .to_return(status: 500, body: '{"message":"Internal Server Error"}')
 
       expect { client.patch(base_url) }
-        .to(raise_error(RuntimeError, /HTTP PATCH.*failed.*500/))
+        .to(raise_error(GHB::GitHubAPIError, /HTTP PATCH.*failed.*500/))
     end
 
     it 'skips validation when expected_codes is nil' do
@@ -177,7 +193,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         .to_return(status: 503, body: '{}')
 
       expect { client.get(base_url) }
-        .to(raise_error(RuntimeError, /HTTP GET.*failed.*503/))
+        .to(raise_error(GHB::GitHubAPIError, /HTTP GET.*failed.*503/))
     end
 
     it 'retries on Net::OpenTimeout' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
@@ -237,7 +253,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         .to_return(status: 422, body: '{"message":"Unprocessable"}')
 
       expect { client.get(base_url) }
-        .to(raise_error(RuntimeError, /HTTP GET.*failed.*422/))
+        .to(raise_error(GHB::GitHubAPIError, /HTTP GET.*failed.*422/))
 
       expect(a_request(:get, base_url)).to(have_been_made.once)
     end

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
 
   before do
     allow($stdout).to(receive(:puts))
+    # Filesystem safety net. LinterJobBuilder#delete_linter_config /
+    # #copy_linter_config operate on relative paths in the CWD. Without these
+    # default stubs, contexts that let File.exist? call_original delete this
+    # repo's own root linter configs (.rubocop.yml, .yamllint.yml, etc.) when
+    # the suite is run from the repo root. Inner allow/have_received still work.
+    allow(File).to(receive(:delete))
+    allow(FileUtils).to(receive(:ln_s))
   end
 
   describe '#build' do

--- a/spec/ghb/options_spec.rb
+++ b/spec/ghb/options_spec.rb
@@ -245,6 +245,34 @@ RSpec.describe(GHB::Options) do
     end
   end
 
+  describe '#parse (invalid input)' do
+    before do
+      allow(File).to(receive(:exist?).and_return(false))
+    end
+
+    it 'raises InvalidOption on an unknown flag' do
+      expect { described_class.new(['--bogus']).parse }
+        .to(raise_error(OptionParser::InvalidOption))
+    end
+
+    it 'raises MissingArgument when a value-taking flag has no value' do
+      expect { described_class.new(['--organization']).parse }
+        .to(raise_error(OptionParser::MissingArgument))
+    end
+
+    it 'normalizes an empty --excluded_folders value to []' do
+      options = described_class.new(['--excluded_folders', '']).parse
+
+      expect(options.excluded_folders).to(eq([]))
+    end
+
+    it 'drops blank entries from a partially-empty --excluded_folders value' do
+      options = described_class.new(['--excluded_folders', 'vendor,,tmp,']).parse
+
+      expect(options.excluded_folders).to(eq(%w[vendor tmp]))
+    end
+  end
+
   describe '#args_comment' do
     before do
       allow(File).to(receive(:exist?).and_return(false))
@@ -302,6 +330,13 @@ RSpec.describe(GHB::Options) do
 
       options = described_class.new([])
       expect(options.instance_variable_get(:@argv)).to(eq(['--organization', 'My Org', '--skip_slack']))
+    end
+
+    it 'raises a clear ConfigError on malformed quoting instead of a raw Shellwords stack trace' do
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --organization 'unterminated\n"].each))
+
+      expect { described_class.new([]) }
+        .to(raise_error(GHB::ConfigError, /Malformed github-build args/))
     end
   end
 end


### PR DESCRIPTION
## Summary

Addresses the two remaining High-severity findings from the deep code review (BUG-004, TEST-005) and fixes a filesystem-isolation defect uncovered while verifying them: the unit suite deleted the repo's own root linter configs when run from the repo root, because `LinterJobBuilder` operates on relative paths in the CWD and several `linter_job_builder_spec` contexts let `File.exist?` call through without stubbing `File.delete`.

**Key changes:**

- `GitHubAPIClient` now raises a typed `GHB::GitHubAPIError` that includes a truncated (1000-char) response body, so GitHub's actionable `message`/`errors[]` detail is no longer discarded on 4xx/5xx (BUG-004).
- `Application#configure_options` broadens its rescue from `OptionParser::InvalidOption` to the parent `OptionParser::ParseError` (now also handles `MissingArgument`/`AmbiguousOption`) and writes to STDERR via `warn` instead of STDOUT.
- `Options#args_from_file` wraps `Shellwords.split` so a corrupted persisted args comment raises a clear `ConfigError` instead of a raw stack trace; empty `--excluded_folders` entries are dropped.
- Added negative CLI-parsing specs (unknown flag, missing argument, empty/partial `--excluded_folders`, malformed quoting) and API-client specs asserting response-body inclusion and 1000-char truncation (TEST-005).
- Added a filesystem safety-net `before` hook in `linter_job_builder_spec` that defaults `File.delete`/`FileUtils.ln_s` to no-ops, stopping the suite from destroying the repo's root linter configs; inner `allow`/`have_received` expectations are unaffected.

Full suite: 321 examples, 0 failures; line coverage 94.24%, branch 84.73%. RuboCop clean on all changed files. The four root linter configs now survive a full `rspec` run.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified