### PR TITLE
QUAL-017: introduce BuildContext value object for job builders

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -9,6 +9,7 @@ require 'psych'
 
 require_relative 'auto_merge_manager'
 require_relative 'aws_job_builder'
+require_relative 'build_context'
 require_relative 'code_deploy_job_builder'
 require_relative 'dependabot_manager'
 require_relative 'dockerhub_manager'
@@ -65,27 +66,25 @@ module GHB
       workflow_read
       workflow_set_defaults
 
-      VariablesJobBuilder.new(options: @options, new_workflow: @new_workflow).build
-
-      LinterJobBuilder.new(
+      context = BuildContext.new(
         options: @options,
-        submodules: @submodules,
         old_workflow: @old_workflow,
         new_workflow: @new_workflow,
-        file_cache: @file_cache
-      ).build
+        file_cache: @file_cache,
+        submodules: @submodules
+      )
 
-      licenses_builder = LicensesJobBuilder.new(options: @options, old_workflow: @old_workflow, new_workflow: @new_workflow)
+      VariablesJobBuilder.new(context: context).build
+
+      LinterJobBuilder.new(context: context).build
+
+      licenses_builder = LicensesJobBuilder.new(context: context)
       licenses_builder.build
       @unit_tests_conditions = licenses_builder.unit_tests_conditions
 
       language_builder = LanguageJobBuilder.new(
-        options: @options,
-        submodules: @submodules,
-        old_workflow: @old_workflow,
-        new_workflow: @new_workflow,
+        context: context,
         unit_tests_conditions: @unit_tests_conditions,
-        file_cache: @file_cache,
         dependencies_commands: @dependencies_commands
       )
       language_builder.build
@@ -95,15 +94,10 @@ module GHB
 
       collect_required_status_checks
 
-      CodeDeployJobBuilder.new(
-        options: @options,
-        old_workflow: @old_workflow,
-        new_workflow: @new_workflow,
-        code_deploy_pre_steps: @code_deploy_pre_steps
-      ).build
+      CodeDeployJobBuilder.new(context: context, code_deploy_pre_steps: @code_deploy_pre_steps).build
 
-      AwsJobBuilder.new(options: @options, old_workflow: @old_workflow, new_workflow: @new_workflow).build
-      SlackJobBuilder.new(options: @options, old_workflow: @old_workflow, new_workflow: @new_workflow).build
+      AwsJobBuilder.new(context: context).build
+      SlackJobBuilder.new(context: context).build
 
       workflow_write
 
@@ -116,7 +110,7 @@ module GHB
 
       AutoMergeManager.new(auto_merge_workflow: @auto_merge_workflow).save
       DockerhubManager.new(dockerhub_workflow: @dockerhub_workflow).save
-      GitignoreManager.new(options: @options, submodules: @submodules, file_cache: @file_cache).update
+      GitignoreManager.new(context: context).update
       RepositoryConfigurator.new(options: @options, required_status_checks: @required_status_checks, default_branch: @default_branch).configure
 
       @exit_code

--- a/lib/ghb/aws_job_builder.rb
+++ b/lib/ghb/aws_job_builder.rb
@@ -3,10 +3,10 @@
 module GHB
   # Builds the "AWS Commands" job in the workflow.
   class AwsJobBuilder
-    def initialize(options:, old_workflow:, new_workflow:)
-      @options = options
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
+    def initialize(context:)
+      @options = context.options
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
     end
 
     def build

--- a/lib/ghb/build_context.rb
+++ b/lib/ghb/build_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GHB
+  # Immutable bundle of the values shared across job builders, replacing the
+  # recurring (options:, old_workflow:, new_workflow:, file_cache:, submodules:)
+  # keyword-argument clump. Builders that need extra inputs take those as
+  # additional keyword arguments alongside `context:`.
+  #
+  # The referenced workflow / cache / submodules objects are still mutated in
+  # place by the pipeline; only the container itself is frozen.
+  class BuildContext
+    attr_reader :options, :old_workflow, :new_workflow, :file_cache, :submodules
+
+    def initialize(options:, new_workflow: nil, old_workflow: nil, file_cache: {}, submodules: [])
+      @options = options
+      @old_workflow = old_workflow
+      @new_workflow = new_workflow
+      @file_cache = file_cache
+      @submodules = submodules
+      freeze
+    end
+  end
+end

--- a/lib/ghb/code_deploy_job_builder.rb
+++ b/lib/ghb/code_deploy_job_builder.rb
@@ -3,10 +3,10 @@
 module GHB
   # Builds the "Code Deploy" jobs in the workflow.
   class CodeDeployJobBuilder
-    def initialize(options:, old_workflow:, new_workflow:, code_deploy_pre_steps:)
-      @options = options
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
+    def initialize(context:, code_deploy_pre_steps:)
+      @options = context.options
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
       @code_deploy_pre_steps = code_deploy_pre_steps
     end
 

--- a/lib/ghb/gitignore_manager.rb
+++ b/lib/ghb/gitignore_manager.rb
@@ -9,10 +9,10 @@ module GHB
   class GitignoreManager
     include FileScanner
 
-    def initialize(options:, submodules:, file_cache:)
-      @options = options
-      @submodules = submodules
-      @file_cache = file_cache
+    def initialize(context:)
+      @options = context.options
+      @submodules = context.submodules
+      @file_cache = context.file_cache
     end
 
     def update

--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -15,13 +15,13 @@ module GHB
 
     attr_reader :code_deploy_pre_steps, :dependencies_steps, :dependencies_commands
 
-    def initialize(options:, submodules:, old_workflow:, new_workflow:, unit_tests_conditions:, file_cache:, dependencies_commands:)
-      @options = options
-      @submodules = submodules
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
+    def initialize(context:, unit_tests_conditions:, dependencies_commands:)
+      @options = context.options
+      @submodules = context.submodules
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
       @unit_tests_conditions = unit_tests_conditions
-      @file_cache = file_cache
+      @file_cache = context.file_cache
       @code_deploy_pre_steps = []
       @dependencies_steps = []
       @dependencies_commands = dependencies_commands

--- a/lib/ghb/licenses_job_builder.rb
+++ b/lib/ghb/licenses_job_builder.rb
@@ -5,10 +5,10 @@ module GHB
   class LicensesJobBuilder
     attr_reader :unit_tests_conditions
 
-    def initialize(options:, old_workflow:, new_workflow:)
-      @options = options
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
+    def initialize(context:)
+      @options = context.options
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
       @unit_tests_conditions = nil
     end
 

--- a/lib/ghb/linter_job_builder.rb
+++ b/lib/ghb/linter_job_builder.rb
@@ -7,12 +7,12 @@ module GHB
   class LinterJobBuilder
     include FileScanner
 
-    def initialize(options:, submodules:, old_workflow:, new_workflow:, file_cache:)
-      @options = options
-      @submodules = submodules
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
-      @file_cache = file_cache
+    def initialize(context:)
+      @options = context.options
+      @submodules = context.submodules
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
+      @file_cache = context.file_cache
     end
 
     def build

--- a/lib/ghb/slack_job_builder.rb
+++ b/lib/ghb/slack_job_builder.rb
@@ -3,10 +3,10 @@
 module GHB
   # Builds the "Publish Statuses" (Slack) job in the workflow.
   class SlackJobBuilder
-    def initialize(options:, old_workflow:, new_workflow:)
-      @options = options
-      @old_workflow = old_workflow
-      @new_workflow = new_workflow
+    def initialize(context:)
+      @options = context.options
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
     end
 
     def build

--- a/lib/ghb/variables_job_builder.rb
+++ b/lib/ghb/variables_job_builder.rb
@@ -3,9 +3,9 @@
 module GHB
   # Builds the "Prepare Variables" job in the workflow.
   class VariablesJobBuilder
-    def initialize(options:, new_workflow:)
-      @options = options
-      @new_workflow = new_workflow
+    def initialize(context:)
+      @options = context.options
+      @new_workflow = context.new_workflow
     end
 
     def build

--- a/spec/ghb/aws_job_builder_spec.rb
+++ b/spec/ghb/aws_job_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
     it 'returns early when only_dependabot is true' do
       options = instance_double(GHB::Options, only_dependabot: true)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       builder.build
 
@@ -26,7 +26,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
     it 'returns early when .aws file missing' do # rubocop:disable RSpec/ExampleLength
       options = instance_double(GHB::Options, only_dependabot: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('.aws').and_return(false))
 
@@ -44,7 +44,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
         do_name('Prepare Variables')
       end
 
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('.aws').and_return(true))
 
@@ -85,7 +85,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
         do_name('Prepare Variables')
       end
 
-      builder = described_class.new(options: options, old_workflow: old_wf, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_wf, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('.aws').and_return(true))
 

--- a/spec/ghb/code_deploy_job_builder_spec.rb
+++ b/spec/ghb/code_deploy_job_builder_spec.rb
@@ -17,9 +17,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
 
       it 'returns early without adding jobs' do # rubocop:disable RSpec/ExampleLength
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -38,9 +40,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
         allow(File).to(receive(:exist?).with('appspec.yml').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -66,9 +70,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
 
       it 'adds codedeploy and environment jobs' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -82,9 +88,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
 
       it 'creates the codedeploy job with correct name and needs' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -97,9 +105,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
 
       it 'creates beta_deploy, rc_deploy, and prod_deploy environment jobs' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -142,9 +152,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
         end
 
         builder = described_class.new(
-          options: options,
-          old_workflow: old_wf,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_wf,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 
@@ -164,9 +176,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
         pre_steps = [pre_step]
 
         builder = described_class.new(
-          options: options,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: pre_steps
         )
 
@@ -199,9 +213,11 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
         end
 
         builder = described_class.new(
-          options: options,
-          old_workflow: old_wf,
-          new_workflow: new_workflow,
+          context: GHB::BuildContext.new(
+            options: options,
+            old_workflow: old_wf,
+            new_workflow: new_workflow
+          ),
           code_deploy_pre_steps: code_deploy_pre_steps
         )
 

--- a/spec/ghb/gitignore_manager_spec.rb
+++ b/spec/ghb/gitignore_manager_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe(GHB::GitignoreManager) do
       excluded_folders: []
     )
   end
-  let(:manager) { described_class.new(options: mock_options, submodules: submodules, file_cache: file_cache) }
+  let(:manager) { described_class.new(context: GHB::BuildContext.new(options: mock_options, submodules: submodules, file_cache: file_cache)) }
 
   let(:minimal_gitignore_config) do
     {
@@ -32,7 +32,7 @@ RSpec.describe(GHB::GitignoreManager) do
   describe '#update' do
     it 'returns early when skip_gitignore is true' do
       skip_options = instance_double(GHB::Options, skip_gitignore: true)
-      skip_manager = described_class.new(options: skip_options, submodules: [], file_cache: {})
+      skip_manager = described_class.new(context: GHB::BuildContext.new(options: skip_options, submodules: [], file_cache: {}))
 
       allow(File).to(receive(:exist?).with('.gitignore'))
 
@@ -204,7 +204,7 @@ RSpec.describe(GHB::GitignoreManager) do
         languages_config_file: 'config/languages.yaml',
         excluded_folders: %w[var tmp]
       )
-      mgr = described_class.new(options: options, submodules: ['pnp-scripts'], file_cache: {})
+      mgr = described_class.new(context: GHB::BuildContext.new(options: options, submodules: ['pnp-scripts'], file_cache: {}))
       allow(mgr).to(receive(:excluded_dirs_from_config).and_return(['.git']))
 
       expect(mgr.__send__(:build_gitignore_excluded_paths)).to(eq(%w[.git pnp-scripts var tmp]))

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
 
   let(:builder) do
     described_class.new(
-      options: mock_options,
-      submodules: submodules,
-      old_workflow: old_workflow,
-      new_workflow: new_workflow,
+      context: GHB::BuildContext.new(
+        options: mock_options,
+        submodules: submodules,
+        old_workflow: old_workflow,
+        new_workflow: new_workflow,
+        file_cache: file_cache
+      ),
       unit_tests_conditions: unit_tests_conditions,
-      file_cache: file_cache,
       dependencies_commands: dependencies_commands
     )
   end
@@ -88,12 +90,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'returns early when only_dependabot is true' do # rubocop:disable RSpec/ExampleLength
       dependabot_options = instance_double(GHB::Options, only_dependabot: true)
       dependabot_builder = described_class.new(
-        options: dependabot_options,
-        submodules: [],
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: dependabot_options,
+          submodules: [],
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -329,12 +333,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       )
 
       non_strict_builder = described_class.new(
-        options: non_strict_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: non_strict_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -370,12 +376,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       )
 
       codedeploy_builder = described_class.new(
-        options: codedeploy_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: codedeploy_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -414,12 +422,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       env_mismatch_workflow.env[:'MONGODB-VERSION'] = '7.0'
 
       env_mismatch_builder = described_class.new(
-        options: non_strict_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: env_mismatch_workflow,
+        context: GHB::BuildContext.new(
+          options: non_strict_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: env_mismatch_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -459,12 +469,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       version_mismatch_workflow.env[:'MONGODB-VERSION'] = '7.0'
 
       version_mismatch_builder = described_class.new(
-        options: mock_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: version_mismatch_workflow,
+        context: GHB::BuildContext.new(
+          options: mock_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: version_mismatch_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -500,12 +512,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       )
 
       license_builder = described_class.new(
-        options: license_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: license_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -545,12 +559,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       )
 
       mono_builder = described_class.new(
-        options: mono_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: mono_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 
@@ -588,12 +604,14 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       )
 
       mono_svc_builder = described_class.new(
-        options: mono_options,
-        submodules: submodules,
-        old_workflow: old_workflow,
-        new_workflow: new_workflow,
+        context: GHB::BuildContext.new(
+          options: mono_options,
+          submodules: submodules,
+          old_workflow: old_workflow,
+          new_workflow: new_workflow,
+          file_cache: {}
+        ),
         unit_tests_conditions: unit_tests_conditions,
-        file_cache: {},
         dependencies_commands: +''
       )
 

--- a/spec/ghb/licenses_job_builder_spec.rb
+++ b/spec/ghb/licenses_job_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     it 'returns early when only_dependabot is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       options = instance_double(GHB::Options, only_dependabot: true)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       builder.build
 
@@ -27,7 +27,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     it 'sets unit_tests_conditions with Podfile.lock present' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       options = instance_double(GHB::Options, only_dependabot: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(true))
 
@@ -40,7 +40,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     it 'sets unit_tests_conditions without Podfile.lock' do # rubocop:disable RSpec/ExampleLength
       options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
 
@@ -52,7 +52,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     it 'adds licenses job when skip_license_check is false and no Podfile.lock' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
 
@@ -68,7 +68,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     it 'skips licenses job when skip_license_check is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: true)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
 
@@ -98,7 +98,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
 
       options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_wf, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_wf, new_workflow: new_workflow))
 
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
 

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
 
       it 'returns early without adding jobs' do # rubocop:disable RSpec/ExampleLength
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         builder.build
@@ -57,11 +59,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Mock find_files_matching: return matches for rubocop pattern, empty for others
@@ -105,11 +109,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Return matches for everything to prove ignored linters are skipped
@@ -140,11 +146,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Return matches for everything to prove semgrep is skipped
@@ -187,11 +195,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         local_submodules = []
 
         builder = described_class.new(
-          options: options,
-          submodules: local_submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: local_submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         allow(builder).to(receive(:find_files_matching).and_return([]))
@@ -220,11 +230,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match eslint pattern (js files)
@@ -268,11 +280,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:delete))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match semgrep pattern
@@ -331,11 +345,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: {}
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: {}
+          )
         )
 
         # Override cached_file_read to return our custom config
@@ -379,11 +395,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match rubocop pattern (Fastfile)
@@ -437,11 +455,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:delete))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # No files match any linter
@@ -475,11 +495,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:delete))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Return matches for non-ignored linters so they proceed normally
@@ -513,11 +535,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:delete))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # No files match any linter pattern
@@ -559,11 +583,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:delete))
 
         builder = described_class.new(
-          options: options,
-          submodules: [],
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: [],
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match semgrep pattern
@@ -616,11 +642,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         local_submodules = []
 
         builder = described_class.new(
-          options: options,
-          submodules: local_submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: local_submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match golangci pattern (go files)
@@ -662,11 +690,13 @@ RSpec.describe(GHB::LinterJobBuilder) do
         allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
 
         builder = described_class.new(
-          options: options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: file_cache
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
         )
 
         # Only match eslint pattern (js files)

--- a/spec/ghb/slack_job_builder_spec.rb
+++ b/spec/ghb/slack_job_builder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
     it 'returns early when only_dependabot is true' do
       options = instance_double(GHB::Options, only_dependabot: true, skip_slack: false)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       builder.build
 
@@ -26,7 +26,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
     it 'returns early when skip_slack is true' do
       options = instance_double(GHB::Options, only_dependabot: false, skip_slack: true)
       new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       builder.build
 
@@ -42,7 +42,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
         do_name('Prepare Variables')
       end
 
-      builder = described_class.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
       builder.build
 
@@ -77,7 +77,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
         do_name('Prepare Variables')
       end
 
-      builder = described_class.new(options: options, old_workflow: old_wf, new_workflow: new_workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_wf, new_workflow: new_workflow))
 
       builder.build
 

--- a/spec/ghb/variables_job_builder_spec.rb
+++ b/spec/ghb/variables_job_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(GHB::VariablesJobBuilder) do
     it 'returns early when only_dependabot is true' do
       options = instance_double(GHB::Options, only_dependabot: true)
       workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, new_workflow: workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, new_workflow: workflow))
 
       builder.build
 
@@ -15,7 +15,7 @@ RSpec.describe(GHB::VariablesJobBuilder) do
     it 'adds variables job to workflow' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       options = instance_double(GHB::Options, only_dependabot: false)
       workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(options: options, new_workflow: workflow)
+      builder = described_class.new(context: GHB::BuildContext.new(options: options, new_workflow: workflow))
 
       builder.build
 


### PR DESCRIPTION
## Summary

Resolves the QUAL-017 data-clump finding from the deep code review. The recurring `{ options, old_workflow, new_workflow, file_cache, submodules }` keyword-argument clump threaded into every job builder is replaced by a single immutable `GHB::BuildContext` value object. Behaviour-preserving — the existing 321-example suite passes unchanged and RuboCop is clean across all 46 files.

**Key changes:**

- New `lib/ghb/build_context.rb` — immutable value object holding `options`, `old_workflow`, `new_workflow`, `file_cache`, `submodules` (referenced objects are still mutated in place by the pipeline; only the container is frozen).
- `Application#execute` builds one `BuildContext` and passes it to all builders; per-builder extras (`unit_tests_conditions`, `dependencies_commands`, `code_deploy_pre_steps`) remain explicit keyword args alongside `context:`.
- All 8 builders/managers updated to `initialize(context:, ...)` and destructure from it: `variables`, `linter`, `licenses`, `language`, `code_deploy`, `aws`, `slack` job builders + `gitignore_manager`.
- 8 corresponding builder specs updated to construct via `GHB::BuildContext.new(...)`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Behaviour-preserving refactor; the existing 321-example suite (updated for the new constructor) covers these paths and passes unchanged.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified