### PR TITLE
DOC-001: document config/*.yaml schemas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * [Usage](#usage)
   * [Examples](#examples)
   * [Argument Persistence](#argument-persistence)
+  * [Configuration Files](#configuration-files)
   * [Feature Triggers](#feature-triggers)
   * [Required Secrets](#required-secrets)
 * [Contributing](#contributing)
@@ -118,6 +119,80 @@ To change the persisted arguments, either:
 
 * Run `github-build` again with the new set of flags, or
 * Edit the `# github-build ...` comment at the top of the build file directly
+
+### Configuration Files
+
+`github-build` ships sensible defaults under `config/`. Each file can be overridden with a CLI flag pointing at your
+own copy. Required top-level keys are validated at startup — a missing key fails fast with a clear `ConfigError`.
+
+#### Linters (`--linters_config_file`, default `config/linters.yaml`)
+
+A map of linter id → definition. Each entry **must** define `short_name`, `long_name`, `uses`, `path`, and
+`pattern`. Optional keys: `condition` (a GitHub Actions `if:` expression), `config` (linter config file to copy).
+
+```yaml
+actionlint:
+  short_name: Actionlint
+  long_name: Github Actions Linter
+  uses: cloud-officer/ci-actions/linters/actionlint
+  path: ".github/workflows"
+  pattern: ".*\\.(yml|yaml)$"
+  condition: "github.event_name == 'pull_request'" # optional
+  config:                                           # optional
+```
+
+#### Languages (`--languages_config_file`, default `config/languages.yaml`)
+
+A map of language id → definition. Each entry **must** define `short_name` and `long_name`. Common optional keys:
+`file_extension`, `version_files[]`, `setup_options[]` (each `{ name, value }`), `dependencies[]` (each with at
+least `dependency_file`, plus `package_manager_name`/`package_manager_default`/`package_manager_update`,
+optional `install_dirs[]` and `*_dependency` service markers), `unit_test_framework_name`,
+`unit_test_framework_default`. A top-level `excluded_dirs[]` lists directories to skip during file scanning.
+
+```yaml
+ruby:
+  short_name: ruby
+  long_name: Ruby
+  file_extension: rb
+  version_files:
+    - .ruby-version
+  dependencies:
+    - dependency_file: Gemfile
+      package_manager_name: Bundler
+      package_manager_default: bundle install
+      package_manager_update: bundle update
+  unit_test_framework_name: RSpec
+  unit_test_framework_default: bundle exec rspec
+```
+
+#### Service options (`--options-apt`, `--options-mongodb`, `--options-mysql`, `--options-redis`, `--options-elasticsearch`)
+
+Each file has a top-level `options:` list; every entry **must** define `name` (an optional `value` becomes the
+default). These map to environment variables consumed by the generated setup step.
+
+```yaml
+options:
+  - name: apt-packages
+    value:
+```
+
+#### Gitignore (`--gitignore_config_file`, default `config/gitignore.yaml`)
+
+* `always_enabled:` — list of [gitignore.io](https://gitignore.io) template names always included.
+* `extension_detection:` — map of template → detection rule (`extensions[]`, `files[]`, and/or
+  `packages: { <file>: [<regex>...] }`); the template is added when the project matches.
+* `custom_patterns:` — map of tool → `{ patterns: [...] }`, always appended under an AI-Assistants section.
+
+```yaml
+always_enabled:
+  - linux
+  - macos
+custom_patterns:
+  claudecode:
+    patterns:
+      - "# Claude Code"
+      - ".claude/"
+```
 
 ### Feature Triggers
 


### PR DESCRIPTION
## Summary

Resolves the DOC-001 documentation-completeness finding. The README documented the config-override flags but never the shape of the YAML files they point at, forcing users authoring overrides to reverse-engineer the contract from the bundled configs or runtime `ConfigError`s. Adds a "Configuration Files" section under Usage describing each file's purpose, required vs optional keys (matching `validate_config_schema`), and a minimal example.

**Key changes:**

- New "Configuration Files" subsection in `README.md` covering linters, languages, the five service-option files, and gitignore — each with required keys and a minimal example.
- Added the section to the Table of Contents.

markdownlint-cli2: 0 errors.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; no code paths affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified