### PR TITLE
Test-hygiene batch: TEST-012/013/014/016/017

### DIFF
--- a/spec/bin/github_build_spec.rb
+++ b/spec/bin/github_build_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'tmpdir'
+
+# Integration coverage for the bin/github-build.rb rescue chain. Runs the real
+# entry script as a subprocess so the GHB::ConfigError rescue (clean message on
+# STDERR, exit 1, no backtrace) is exercised end-to-end. Guards against a
+# regression where ConfigError becomes a RuntimeError (would still exit 1 but
+# dump a noisy backtrace).
+RSpec.describe('bin/github-build.rb') do # rubocop:disable RSpec/DescribeClass
+  let(:script) { File.expand_path('../../bin/github-build.rb', __dir__) }
+
+  def run_in_tmpdir(*, env: {})
+    Dir.mktmpdir('ghb-bin') do |dir|
+      return Open3.capture3(env, RbConfig.ruby, script, *, chdir: dir)
+    end
+  end
+
+  it 'exits 1 with a clean STDERR message and no backtrace on ConfigError' do # rubocop:disable RSpec/MultipleExpectations
+    stdout, stderr, status = run_in_tmpdir('--linters_config_file', 'does-not-exist.yaml', '--skip_repository_settings')
+
+    expect(status.exitstatus).to(eq(1))
+    expect(stderr).to(match(/Error: Missing required .* file: does-not-exist\.yaml/))
+    expect(stdout).to(be_empty)
+    expect(stderr).not_to(match(%r{lib/ghb/.*\.rb:\d+:in}))
+  end
+
+  it 'writes the error to STDERR, not STDOUT' do # rubocop:disable RSpec/MultipleExpectations
+    stdout, stderr, = run_in_tmpdir('--linters_config_file', 'does-not-exist.yaml', '--skip_repository_settings')
+
+    expect(stdout).not_to(include('Error:'))
+    expect(stderr).to(include('Error:'))
+  end
+end

--- a/spec/ghb/application_spec.rb
+++ b/spec/ghb/application_spec.rb
@@ -138,12 +138,9 @@ RSpec.describe(GHB::Application) do
           file_extension: bad
       YAML
 
-      call_count = 0
       allow(File).to(receive(:exist?).and_return(true))
-      allow(File).to(receive(:read)) do
-        call_count += 1
-        call_count == 1 ? linters_yaml : languages_yaml
-      end
+      allow(File).to(receive(:read).with(/linters\.yaml/).and_return(linters_yaml))
+      allow(File).to(receive(:read).with(/languages\.yaml/).and_return(languages_yaml))
 
       config_app = config_test_class.new(mock_options)
 
@@ -158,13 +155,8 @@ RSpec.describe(GHB::Application) do
           - value: some_value
       YAML
 
-      call_count = 0
-      allow(File).to(receive(:exist?).and_return(true))
-      allow(File).to(receive(:read)) do
-        call_count += 1
-        # linters (1), languages (2), apt_options (3)
-        call_count == 3 ? options_yaml : valid_yaml
-      end
+      allow(File).to(receive_messages(exist?: true, read: valid_yaml))
+      allow(File).to(receive(:read).with(%r{options/apt\.yaml}).and_return(options_yaml))
 
       config_app = config_test_class.new(mock_options)
 

--- a/spec/ghb/file_scanner_spec.rb
+++ b/spec/ghb/file_scanner_spec.rb
@@ -158,8 +158,8 @@ RSpec.describe(GHB::FileScanner) do
     end
 
     it 'does not execute shell commands in patterns' do
-      malicious_pattern = '$(touch /tmp/pwned)'
-      pwned_file = '/tmp/pwned'
+      pwned_file = File.join(temp_dir, 'pwned')
+      malicious_pattern = "$(touch #{pwned_file})"
       FileUtils.rm_f(pwned_file)
 
       # This should not create the file

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         call_count += 1
         raise(Net::OpenTimeout, 'execution expired') if call_count < 3
 
-        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+        instance_double(HTTParty::Response, code: 200, body: '{}')
       end
 
       response = client.get(base_url)
@@ -232,7 +232,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         call_count += 1
         raise(Net::ReadTimeout, 'execution expired') if call_count < 2
 
-        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+        instance_double(HTTParty::Response, code: 200, body: '{}')
       end
 
       response = client.get(base_url)
@@ -247,7 +247,7 @@ RSpec.describe(GHB::GitHubAPIClient) do
         call_count += 1
         raise(Errno::ECONNRESET, 'Connection reset by peer') if call_count < 2
 
-        double('response', code: 200, body: '{}', message: 'OK') # rubocop:disable RSpec/VerifiedDoubles
+        instance_double(HTTParty::Response, code: 200, body: '{}')
       end
 
       response = client.get(base_url)

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -672,17 +672,12 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
   private
 
   def stub_config_file_reads(languages_yaml)
-    allow(builder).to(receive(:cached_file_read)) do |path|
-      case path
-      when /languages\.yaml/ then languages_yaml
-      when /apt\.yaml/ then apt_config_yaml
-      when /mongodb\.yaml/ then mongodb_config_yaml
-      when /mysql\.yaml/ then mysql_config_yaml
-      when /redis\.yaml/ then redis_config_yaml
-      when /elasticsearch\.yaml/ then elasticsearch_config_yaml
-      else raise("Unexpected config file read: #{path}")
-      end
-    end
+    allow(builder).to(receive(:cached_file_read).with(/languages\.yaml/).and_return(languages_yaml))
+    allow(builder).to(receive(:cached_file_read).with(/apt\.yaml/).and_return(apt_config_yaml))
+    allow(builder).to(receive(:cached_file_read).with(/mongodb\.yaml/).and_return(mongodb_config_yaml))
+    allow(builder).to(receive(:cached_file_read).with(/mysql\.yaml/).and_return(mysql_config_yaml))
+    allow(builder).to(receive(:cached_file_read).with(/redis\.yaml/).and_return(redis_config_yaml))
+    allow(builder).to(receive(:cached_file_read).with(/elasticsearch\.yaml/).and_return(elasticsearch_config_yaml))
   end
 
   def stub_go_language_detection
@@ -693,16 +688,11 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
   end
 
   def stub_non_strict_config_file_reads(target_builder, languages_yaml)
-    allow(target_builder).to(receive(:cached_file_read)) do |path|
-      case path
-      when /languages\.yaml/ then languages_yaml
-      when /apt\.yaml/ then apt_config_yaml
-      when /mongodb\.yaml/ then mongodb_config_yaml
-      when /mysql\.yaml/ then mysql_config_yaml
-      when /redis\.yaml/ then redis_config_yaml
-      when /elasticsearch\.yaml/ then elasticsearch_config_yaml
-      else raise("Unexpected config file read: #{path}")
-      end
-    end
+    allow(target_builder).to(receive(:cached_file_read).with(/languages\.yaml/).and_return(languages_yaml))
+    allow(target_builder).to(receive(:cached_file_read).with(/apt\.yaml/).and_return(apt_config_yaml))
+    allow(target_builder).to(receive(:cached_file_read).with(/mongodb\.yaml/).and_return(mongodb_config_yaml))
+    allow(target_builder).to(receive(:cached_file_read).with(/mysql\.yaml/).and_return(mysql_config_yaml))
+    allow(target_builder).to(receive(:cached_file_read).with(/redis\.yaml/).and_return(redis_config_yaml))
+    allow(target_builder).to(receive(:cached_file_read).with(/elasticsearch\.yaml/).and_return(elasticsearch_config_yaml))
   end
 end

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -69,13 +69,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Mock find_files_matching: return matches for rubocop pattern, empty for others
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('Fastfile')
-            ['app.rb']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('Fastfile')), anything).and_return(['app.rb']))
 
         # Allow copy_linter_config internals
         allow(File).to(receive(:exist?).with('/linters/.rubocop.yml').and_return(false))
@@ -240,13 +235,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match eslint pattern (js files)
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('js')
-            ['app.js']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('js')), anything).and_return(['app.js']))
 
         allow(builder).to(receive(:copy_linter_config))
 
@@ -290,13 +280,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match semgrep pattern
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('swift') && pattern.source.include?('py')
-            ['app.py']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, satisfy { |p| p.source.include?('swift') && p.source.include?('py') }, anything).and_return(['app.py']))
 
         # Semgrep config is .semgrepignore with preserve_config: true
         # No script_path (no .gitmodules), so script_path is nil
@@ -355,15 +340,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Override cached_file_read to return our custom config
-        allow(builder).to(receive(:cached_file_read).and_return(custom_linters_yaml))
-
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('custom')
-            ['test.custom']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive_messages(cached_file_read: custom_linters_yaml, find_files_matching: []))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('custom')), anything).and_return(['test.custom']))
 
         builder.build
 
@@ -405,13 +383,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match rubocop pattern (Fastfile)
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('Fastfile')
-            ['Fastfile']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('Fastfile')), anything).and_return(['Fastfile']))
 
         # No script_path, no preserve_config -> falls through to atomic_copy_config
         allow(File).to(receive(:exist?).with('/linters/.rubocop.yml').and_return(false))
@@ -593,13 +566,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match semgrep pattern
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('swift') && pattern.source.include?('py')
-            ['app.py']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, satisfy { |p| p.source.include?('swift') && p.source.include?('py') }, anything).and_return(['app.py']))
 
         # script_path has the config
         allow(File).to(receive(:exist?).with('scripts-repo/linters/.semgrepignore').and_return(true))
@@ -652,13 +620,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match golangci pattern (go files)
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('go')
-            ['main.go']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('go')), anything).and_return(['main.go']))
 
         # script_path will be 'scripts-repo' (contains 'scripts')
         # Config file is .golangci.yml
@@ -700,13 +663,8 @@ RSpec.describe(GHB::LinterJobBuilder) do
         )
 
         # Only match eslint pattern (js files)
-        allow(builder).to(receive(:find_files_matching)) do |_path, pattern, _excluded|
-          if pattern.source.include?('js')
-            ['app.js']
-          else
-            []
-          end
-        end
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('js')), anything).and_return(['app.js']))
 
         # No script_path, but local linters/ directory has the config
         allow(File).to(receive(:exist?).with('linters/.eslintrc.json').and_return(true))


### PR DESCRIPTION
## Summary

Resolves the five 🔵 Low test-hygiene findings from the deep code review. Spec-only — no production code changed; the full suite (now 340 examples) passes and RuboCop is clean across all 50 files. Coverage holds at 98.6% line / 87.8% branch.

**Key changes:**

- **TEST-012** — replaced 10 stub-side "mini-router" blocks (conditional logic inside `receive { … }`) with explicit `.with(matcher)` + default stubs: 8 `find_files_matching` blocks in `linter_job_builder_spec` now use `an_object_having_attributes(source: a_string_including(…))` / `satisfy`, and the 2 `cached_file_read` `case` routers in `language_job_builder_spec` are now one `.with(/…\.yaml/)` stub per file.
- **TEST-013** — switched the 3 unverified `double('response', …)` in `git_hub_api_client_spec` to `instance_double(HTTParty::Response, code:, body:)` (dropped the delegated, unverifiable `message:` which was unused in those 200-success retry tests).
- **TEST-014** — `file_scanner_spec` shell-injection sentinel moved from the shared `/tmp/pwned` into the per-example `Dir.mktmpdir` directory.
- **TEST-016** — `application_spec` config-validation stubs bound by path matcher (`receive(:read).with(/…/)`) instead of brittle call-count routing.
- **TEST-017** — new `spec/bin/github_build_spec.rb` runs `bin/github-build.rb` as a subprocess and asserts the `ConfigError` rescue path: exit 1, clean message on STDERR (not STDOUT), no backtrace.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified