### PR TITLE
Remove dead --only_dependabot and --skip_dependabot flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ options
         --languages_config_file file Path to languages config file
         --linters_config_file file   Path to linters config file
         --mono_repo                  Scan one level deep for language dependency files
-        --only_dependabot            Just do Dependabot and nothing else
         --options-apt file           Path to APT options file
         --options-mongodb file       Path to MongoDB options file
         --options-mysql file         Path to MySQL options file
@@ -67,7 +66,6 @@ options
         --options-elasticsearch file Path to Elasticsearch options file
         --organization organization  GitHub organization
         --skip_semgrep               Skip Semgrep
-        --skip_dependabot            Skip dependabot
         --skip_gitignore             Skip update of gitignore file
         --skip_license_check         Skip license check
         --skip_repository_settings   Skip check of repository settings
@@ -86,7 +84,7 @@ environment variable to enable the repository settings check.
 On this repository.
 
 ```bash
-./bin/github-build.rb --skip_dependabot  --skip_slack
+./bin/github-build.rb --skip_slack
 
 Generating build file...
 Reading current build file .github/workflows/build.yml...
@@ -108,7 +106,7 @@ When you run `github-build` with command-line arguments, they are saved as a com
 generated build file:
 
 ```yaml
-# github-build --skip_dependabot --skip_slack
+# github-build --skip_slack
 name: CI
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,6 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `languages_config_file`: Path to languages config file
 - `linters_config_file`: Path to linters config file
 - `mono_repo`: Scan one level deep for language dependency files
-- `only_dependabot`: Only generate dependabot workflow
 - `options_config_file_apt`: Path to APT options config
 - `options_config_file_mongodb`: Path to MongoDB options config
 - `options_config_file_mysql`: Path to MySQL options config
@@ -186,7 +185,6 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `options_config_file_elasticsearch`: Path to Elasticsearch options config
 - `organization`: GitHub organization name
 - `original_argv`: Original command-line arguments for reproducibility
-- `skip_dependabot`: Skip dependabot workflow generation
 - `skip_gitignore`: Skip gitignore updates
 - `skip_license_check`: Skip license checking job
 - `skip_repository_settings`: Skip GitHub repository settings configuration

--- a/lib/ghb/aws_job_builder.rb
+++ b/lib/ghb/aws_job_builder.rb
@@ -10,8 +10,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       return unless File.exist?('.aws')
 
       puts('    Adding aws commands...')

--- a/lib/ghb/code_deploy_job_builder.rb
+++ b/lib/ghb/code_deploy_job_builder.rb
@@ -11,8 +11,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       return unless File.exist?('appspec.yml')
 
       puts('    Adding codedeploy...')

--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -29,8 +29,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       puts('    Detecting languages...')
       languages = Psych.safe_load(cached_file_read("#{__dir__}/../../#{@options.languages_config_file}"))&.deep_symbolize_keys
       options_apt = Psych.safe_load(cached_file_read("#{__dir__}/../../#{@options.options_config_file_apt}"))&.deep_symbolize_keys&.[](:options)

--- a/lib/ghb/licenses_job_builder.rb
+++ b/lib/ghb/licenses_job_builder.rb
@@ -13,8 +13,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       if File.exist?('Podfile.lock')
         @unit_tests_conditions = "needs.variables.outputs.SKIP_LICENSES != '1' || needs.variables.outputs.SKIP_TESTS != '1'"
       else

--- a/lib/ghb/linter_job_builder.rb
+++ b/lib/ghb/linter_job_builder.rb
@@ -16,8 +16,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       puts('    Detecting linters...')
       linters = Psych.safe_load(cached_file_read("#{__dir__}/../../#{@options.linters_config_file}"))&.deep_symbolize_keys
       script_path = nil

--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -24,7 +24,6 @@ module GHB
       @ignored_linters = {}
       @languages_config_file = DEFAULT_LANGUAGES_CONFIG_FILE
       @linters_config_file = DEFAULT_LINTERS_CONFIG_FILE
-      @only_dependabot = false
       @options_config_file_apt = OPTIONS_APT_CONFIG_FILE
       @options_config_file_mongodb = OPTIONS_MONGODB_CONFIG_FILE
       @options_config_file_mysql = OPTIONS_MYSQL_CONFIG_FILE
@@ -32,7 +31,6 @@ module GHB
       @options_config_file_elasticsearch = OPTIONS_ELASTICSEARCH_CONFIG_FILE
       @organization = Dir.pwd.split('/')[-2]
       @parser = OptionParser.new
-      @skip_dependabot = false
       @skip_semgrep = false
       @skip_gitignore = false
       @skip_license_check = false
@@ -46,7 +44,7 @@ module GHB
       setup_parser
     end
 
-    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :mono_repo, :only_dependabot, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_dependabot, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check, :sync_required_status_checks
+    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :mono_repo, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check, :sync_required_status_checks
 
     def parse
       @parser.parse!(@argv)
@@ -161,10 +159,6 @@ module GHB
         @mono_repo = true
       end
 
-      @parser.on('', '--only_dependabot', 'Just do Dependabot and nothing else') do
-        @only_dependabot = true
-      end
-
       @parser.on('', '--no_strict_version_check', 'Do not auto-update when VERSION options do not match recommended defaults') do
         @strict_version_check = false
       end
@@ -178,10 +172,6 @@ module GHB
     def setup_skip_options
       @parser.on('', '--skip_semgrep', 'Skip Semgrep') do
         @skip_semgrep = true
-      end
-
-      @parser.on('', '--skip_dependabot', 'Skip dependabot') do
-        @skip_dependabot = true
       end
 
       @parser.on('', '--skip_gitignore', 'Skip update of gitignore file') do

--- a/lib/ghb/slack_job_builder.rb
+++ b/lib/ghb/slack_job_builder.rb
@@ -10,7 +10,7 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot or @options.skip_slack
+      return if @options.skip_slack
 
       puts('    Adding slack...')
       needs = @new_workflow.jobs.keys.map(&:to_s)

--- a/lib/ghb/variables_job_builder.rb
+++ b/lib/ghb/variables_job_builder.rb
@@ -9,8 +9,6 @@ module GHB
     end
 
     def build
-      return if @options.only_dependabot
-
       @new_workflow.do_job(:variables) do
         do_name('Prepare Variables')
         do_runs_on(DEFAULT_UBUNTU_VERSION)

--- a/spec/ghb/aws_job_builder_spec.rb
+++ b/spec/ghb/aws_job_builder_spec.rb
@@ -13,18 +13,8 @@ RSpec.describe(GHB::AwsJobBuilder) do
       workflow
     end
 
-    it 'returns early when only_dependabot is true' do
-      options = instance_double(GHB::Options, only_dependabot: true)
-      new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
-
-      builder.build
-
-      expect(new_workflow.jobs).to(be_empty)
-    end
-
     it 'returns early when .aws file missing' do # rubocop:disable RSpec/ExampleLength
-      options = instance_double(GHB::Options, only_dependabot: false)
+      options = instance_double(GHB::Options)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -36,7 +26,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
     end
 
     it 'adds aws job when .aws file exists' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false)
+      options = instance_double(GHB::Options)
       new_workflow = GHB::Workflow.new('Test')
 
       # Add a pre-existing job so needs has something to reference
@@ -78,7 +68,7 @@ RSpec.describe(GHB::AwsJobBuilder) do
         end
       end
 
-      options = instance_double(GHB::Options, only_dependabot: false)
+      options = instance_double(GHB::Options)
       new_workflow = GHB::Workflow.new('Test')
 
       new_workflow.do_job(:variables) do

--- a/spec/ghb/code_deploy_job_builder_spec.rb
+++ b/spec/ghb/code_deploy_job_builder_spec.rb
@@ -10,30 +10,9 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
   end
 
   describe '#build' do
-    context 'when only_dependabot is true' do
-      let(:options) do
-        instance_double(GHB::Options, only_dependabot: true)
-      end
-
-      it 'returns early without adding jobs' do # rubocop:disable RSpec/ExampleLength
-        builder = described_class.new(
-          context: GHB::BuildContext.new(
-            options: options,
-            old_workflow: old_workflow,
-            new_workflow: new_workflow
-          ),
-          code_deploy_pre_steps: code_deploy_pre_steps
-        )
-
-        builder.build
-
-        expect(new_workflow.jobs).to(be_empty)
-      end
-    end
-
     context 'when appspec.yml is missing' do
       let(:options) do
-        instance_double(GHB::Options, only_dependabot: false)
+        instance_double(GHB::Options)
       end
 
       it 'returns early without adding jobs' do # rubocop:disable RSpec/ExampleLength
@@ -56,7 +35,7 @@ RSpec.describe(GHB::CodeDeployJobBuilder) do
 
     context 'when appspec.yml exists' do
       let(:options) do
-        instance_double(GHB::Options, only_dependabot: false, application_name: 'myapp')
+        instance_double(GHB::Options, application_name: 'myapp')
       end
 
       before do

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
   let(:mock_options) do
     instance_double(
       GHB::Options,
-      only_dependabot: false,
       mono_repo: false,
       excluded_folders: [],
       skip_license_check: true,
@@ -87,27 +86,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
   let(:swift_language_yaml) { Psych.dump(swift_only_config.deep_stringify_keys) }
 
   describe '#build' do # rubocop:disable RSpec/MultipleMemoizedHelpers
-    it 'returns early when only_dependabot is true' do # rubocop:disable RSpec/ExampleLength
-      dependabot_options = instance_double(GHB::Options, only_dependabot: true)
-      dependabot_builder = described_class.new(
-        context: GHB::BuildContext.new(
-          options: dependabot_options,
-          submodules: [],
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: {}
-        ),
-        unit_tests_conditions: unit_tests_conditions,
-        dependencies_commands: +''
-      )
-
-      allow(dependabot_builder).to(receive(:cached_file_read))
-
-      dependabot_builder.build
-
-      expect(dependabot_builder).not_to(have_received(:cached_file_read))
-    end
-
     it 'skips languages with nil file_extension' do
       stub_config_file_reads(swift_language_yaml)
 
@@ -318,7 +296,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'prints warning but does not exit when version file mismatches and strict_version_check is false' do # rubocop:disable RSpec/ExampleLength
       non_strict_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
@@ -361,7 +338,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'populates code_deploy_pre_steps when force_codedeploy_setup is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       codedeploy_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
@@ -404,7 +380,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'prints warning when existing env value differs from option value' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       non_strict_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
@@ -497,7 +472,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'adds Licenses step when Podfile.lock exists and skip_license_check is false' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       license_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: false,
         excluded_folders: [],
         skip_license_check: false,
@@ -544,7 +518,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'detects mono_repo subdirectory dependencies and adds per-subdir steps' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       mono_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: true,
         excluded_folders: [],
         skip_license_check: true,
@@ -589,7 +562,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'detects services in mono_repo subdirectory dependency files' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       mono_options = instance_double(
         GHB::Options,
-        only_dependabot: false,
         mono_repo: true,
         excluded_folders: [],
         skip_license_check: true,

--- a/spec/ghb/licenses_job_builder_spec.rb
+++ b/spec/ghb/licenses_job_builder_spec.rb
@@ -13,19 +13,8 @@ RSpec.describe(GHB::LicensesJobBuilder) do
       workflow
     end
 
-    it 'returns early when only_dependabot is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: true)
-      new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
-
-      builder.build
-
-      expect(new_workflow.jobs).to(be_empty)
-      expect(builder.unit_tests_conditions).to(be_nil)
-    end
-
     it 'sets unit_tests_conditions with Podfile.lock present' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false)
+      options = instance_double(GHB::Options)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -38,7 +27,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     end
 
     it 'sets unit_tests_conditions without Podfile.lock' do # rubocop:disable RSpec/ExampleLength
-      options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
+      options = instance_double(GHB::Options, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -50,7 +39,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     end
 
     it 'adds licenses job when skip_license_check is false and no Podfile.lock' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
+      options = instance_double(GHB::Options, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -66,7 +55,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
     end
 
     it 'skips licenses job when skip_license_check is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: true)
+      options = instance_double(GHB::Options, skip_license_check: true)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -96,7 +85,7 @@ RSpec.describe(GHB::LicensesJobBuilder) do
         end
       end
 
-      options = instance_double(GHB::Options, only_dependabot: false, skip_license_check: false)
+      options = instance_double(GHB::Options, skip_license_check: false)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_wf, new_workflow: new_workflow))
 

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -18,33 +18,10 @@ RSpec.describe(GHB::LinterJobBuilder) do
   end
 
   describe '#build' do
-    context 'when only_dependabot is true' do
-      let(:options) do
-        instance_double(GHB::Options, only_dependabot: true)
-      end
-
-      it 'returns early without adding jobs' do # rubocop:disable RSpec/ExampleLength
-        builder = described_class.new(
-          context: GHB::BuildContext.new(
-            options: options,
-            submodules: submodules,
-            old_workflow: old_workflow,
-            new_workflow: new_workflow,
-            file_cache: file_cache
-          )
-        )
-
-        builder.build
-
-        expect(new_workflow.jobs).to(be_empty)
-      end
-    end
-
     context 'when detecting linters' do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -91,7 +68,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: { rubocop: true, eslint: true },
           excluded_folders: [],
@@ -128,7 +104,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: true,
           ignored_linters: {},
           excluded_folders: [],
@@ -164,7 +139,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -212,7 +186,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -254,7 +227,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -303,7 +275,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -360,7 +331,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -413,7 +383,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -453,7 +422,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: { eslint: true },
           excluded_folders: [],
@@ -493,7 +461,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -533,7 +500,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -587,7 +553,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],
@@ -639,7 +604,6 @@ RSpec.describe(GHB::LinterJobBuilder) do
       let(:options) do
         instance_double(
           GHB::Options,
-          only_dependabot: false,
           skip_semgrep: false,
           ignored_linters: {},
           excluded_folders: [],

--- a/spec/ghb/options_spec.rb
+++ b/spec/ghb/options_spec.rb
@@ -21,13 +21,11 @@ RSpec.describe(GHB::Options) do
       expect(options.gitignore_config_file).to(eq(default_gitignore_config))
       expect(options.excluded_folders).to(eq([]))
       expect(options.ignored_linters).to(eq({}))
-      expect(options.skip_dependabot).to(be(false))
       expect(options.skip_semgrep).to(be(false))
       expect(options.skip_gitignore).to(be(false))
       expect(options.skip_license_check).to(be(false))
       expect(options.skip_repository_settings).to(be(false))
       expect(options.skip_slack).to(be(false))
-      expect(options.only_dependabot).to(be(false))
       expect(options.force_codedeploy_setup).to(be(false))
       expect(options.get_ignored_folders).to(be(false))
       expect(options.strict_version_check).to(be(true))
@@ -99,13 +97,6 @@ RSpec.describe(GHB::Options) do
       expect(options.ignored_linters).to(eq({ rubocop: true, eslint: true }))
     end
 
-    it 'parses --skip_dependabot' do
-      options = described_class.new(['--skip_dependabot'])
-      options.parse
-
-      expect(options.skip_dependabot).to(be(true))
-    end
-
     it 'parses --skip_semgrep' do
       options = described_class.new(['--skip_semgrep'])
       options.parse
@@ -139,13 +130,6 @@ RSpec.describe(GHB::Options) do
       options.parse
 
       expect(options.skip_slack).to(be(true))
-    end
-
-    it 'parses --only_dependabot' do
-      options = described_class.new(['--only_dependabot'])
-      options.parse
-
-      expect(options.only_dependabot).to(be(true))
     end
 
     it 'parses --force_codedeploy_setup' do
@@ -224,7 +208,6 @@ RSpec.describe(GHB::Options) do
           '--organization',
           'TestOrg',
           '--skip_slack',
-          '--skip_dependabot',
           '--excluded_folders',
           'vendor,tmp'
         ]
@@ -233,7 +216,6 @@ RSpec.describe(GHB::Options) do
 
       expect(options.organization).to(eq('TestOrg'))
       expect(options.skip_slack).to(be(true))
-      expect(options.skip_dependabot).to(be(true))
       expect(options.excluded_folders).to(eq(%w[vendor tmp]))
     end
 

--- a/spec/ghb/slack_job_builder_spec.rb
+++ b/spec/ghb/slack_job_builder_spec.rb
@@ -13,18 +13,8 @@ RSpec.describe(GHB::SlackJobBuilder) do
       workflow
     end
 
-    it 'returns early when only_dependabot is true' do
-      options = instance_double(GHB::Options, only_dependabot: true, skip_slack: false)
-      new_workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
-
-      builder.build
-
-      expect(new_workflow.jobs).to(be_empty)
-    end
-
     it 'returns early when skip_slack is true' do
-      options = instance_double(GHB::Options, only_dependabot: false, skip_slack: true)
+      options = instance_double(GHB::Options, skip_slack: true)
       new_workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, old_workflow: old_workflow, new_workflow: new_workflow))
 
@@ -34,7 +24,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
     end
 
     it 'adds slack job to workflow' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false, skip_slack: false)
+      options = instance_double(GHB::Options, skip_slack: false)
       new_workflow = GHB::Workflow.new('Test')
 
       # Add a pre-existing job so needs has something to reference
@@ -70,7 +60,7 @@ RSpec.describe(GHB::SlackJobBuilder) do
         end
       end
 
-      options = instance_double(GHB::Options, only_dependabot: false, skip_slack: false)
+      options = instance_double(GHB::Options, skip_slack: false)
       new_workflow = GHB::Workflow.new('Test')
 
       new_workflow.do_job(:variables) do

--- a/spec/ghb/variables_job_builder_spec.rb
+++ b/spec/ghb/variables_job_builder_spec.rb
@@ -2,18 +2,8 @@
 
 RSpec.describe(GHB::VariablesJobBuilder) do
   describe '#build' do
-    it 'returns early when only_dependabot is true' do
-      options = instance_double(GHB::Options, only_dependabot: true)
-      workflow = GHB::Workflow.new('Test')
-      builder = described_class.new(context: GHB::BuildContext.new(options: options, new_workflow: workflow))
-
-      builder.build
-
-      expect(workflow.jobs).to(be_empty)
-    end
-
     it 'adds variables job to workflow' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      options = instance_double(GHB::Options, only_dependabot: false)
+      options = instance_double(GHB::Options)
       workflow = GHB::Workflow.new('Test')
       builder = described_class.new(context: GHB::BuildContext.new(options: options, new_workflow: workflow))
 


### PR DESCRIPTION
## Summary

Removes two CLI flags that did not work as documented, surfaced by the deep code review (findings GHB-007 and Q5).

`--only_dependabot` ("Just do Dependabot and nothing else") was wired into every job builder via `return if @options.only_dependabot`, but `Application#execute` never short-circuited. Passing it produced a jobless, stripped `build.yml` **and** deleted `.github/workflows/dependencies.yml` (because `DependabotManager#save` saw no `:licenses` job) — destructive behaviour, the opposite of the flag's stated purpose.

`--skip_dependabot` ("Skip dependabot") was initialized, exposed via `attr_reader`, documented, and tested for parsing, but its value was never read anywhere — `DependabotManager` always ran, so the flag was a silent no-op.

Both flags were confirmed unused across every consuming repository config (`.repositories-bre/co/in/ugm.yaml` — zero occurrences), so rather than implement the intended behaviour, the dead/misleading surface is removed entirely.

**Key changes:**

- Remove `--only_dependabot` and `--skip_dependabot` option parsing, ivars, and `attr_reader` entries from `lib/ghb/options.rb`
- Drop the `return if @options.only_dependabot` guard from all job builders (aws, code_deploy, language, licenses, linter, variables); simplify `slack_job_builder` to `return if @options.skip_slack`
- Remove both flags from `README.md` usage/examples and from the attribute list in `docs/architecture.md`
- Remove the now-obsolete "returns early when only_dependabot is true" specs and the flag-parsing specs; drop `only_dependabot:` / `skip_dependabot:` keys from `instance_double(GHB::Options)` stubs
- Full suite green (338 examples, 0 failures), RuboCop 0 offenses, markdownlint 0 errors; line coverage 98.5%

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [x] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Behaviour and its flags were removed; the affected specs were deleted/updated and the full suite (338 examples) still passes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

This removes two public CLI flags, so it is technically a breaking change to the command-line interface: any invocation passing `--only_dependabot` or `--skip_dependabot` will now fail with an `OptionParser::InvalidOption` error instead of silently misbehaving. This is intentional and safe — both flags were verified to be unused across all consuming repository configs, `--skip_dependabot` was a no-op, and `--only_dependabot` was actively destructive. Failing fast on the removed flags is preferable to the prior silent data loss.
