### PR TITLE
Cover real validate_config! YAML rescue and rate-limit reset cap

### DIFF
--- a/spec/ghb/application_spec.rb
+++ b/spec/ghb/application_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.describe(GHB::Application) do
   describe '#validate_config!' do
-    let(:temp_dir) { Dir.mktmpdir('ghb-config-test') }
     let(:config_test_class) do
       Class.new(described_class) do
         def initialize(options) # rubocop:disable Lint/MissingSuper
@@ -26,10 +25,6 @@ RSpec.describe(GHB::Application) do
         options_config_file_elasticsearch: 'config/options/elasticsearch.yaml',
         gitignore_config_file: 'config/gitignore.yaml'
       )
-    end
-
-    after do
-      FileUtils.rm_rf(temp_dir)
     end
 
     it 'does not raise when all config files exist and are valid YAML' do
@@ -58,62 +53,20 @@ RSpec.describe(GHB::Application) do
     end
 
     it 'raises ConfigError when a config file has invalid YAML' do # rubocop:disable RSpec/ExampleLength
-      # Create a temp config structure
-      FileUtils.mkdir_p("#{temp_dir}/config/options")
-      File.write("#{temp_dir}/config/linters.yaml", "valid: yaml\n")
-      File.write("#{temp_dir}/config/languages.yaml", 'invalid: yaml: syntax: [')
-      File.write("#{temp_dir}/config/options/apt.yaml", "valid: yaml\n")
-      File.write("#{temp_dir}/config/options/mongodb.yaml", "valid: yaml\n")
-      File.write("#{temp_dir}/config/options/mysql.yaml", "valid: yaml\n")
-      File.write("#{temp_dir}/config/options/redis.yaml", "valid: yaml\n")
-      File.write("#{temp_dir}/config/gitignore.yaml", "valid: yaml\n")
+      config_app = config_test_class.new(mock_options)
 
-      # Stub __dir__ to point to our temp directory
-      temp_options = instance_double(
-        GHB::Options,
-        linters_config_file: "#{temp_dir}/config/linters.yaml",
-        languages_config_file: "#{temp_dir}/config/languages.yaml",
-        options_config_file_apt: "#{temp_dir}/config/options/apt.yaml",
-        options_config_file_mongodb: "#{temp_dir}/config/options/mongodb.yaml",
-        options_config_file_mysql: "#{temp_dir}/config/options/mysql.yaml",
-        options_config_file_redis: "#{temp_dir}/config/options/redis.yaml",
-        gitignore_config_file: "#{temp_dir}/config/gitignore.yaml"
+      # Drive the real #validate_config! and exercise its real
+      # Psych::SyntaxError rescue: return malformed YAML only for the
+      # languages config (parsed after the valid linters config), letting
+      # every other file read through to the real on-disk config.
+      allow(config_app).to(
+        receive(:cached_file_read).and_wrap_original do |original, path|
+          path.end_with?('languages.yaml') ? 'invalid: yaml: syntax: [' : original.call(path)
+        end
       )
 
-      # Create a custom test class that uses absolute paths directly
-      absolute_path_test_class =
-        Class.new do
-          def initialize(options)
-            @options = options
-          end
-
-          def validate_config!
-            config_files = {
-              'linters config': @options.linters_config_file,
-              'languages config': @options.languages_config_file,
-              'APT options': @options.options_config_file_apt,
-              'MongoDB options': @options.options_config_file_mongodb,
-              'MySQL options': @options.options_config_file_mysql,
-              'Redis options': @options.options_config_file_redis,
-              'gitignore config': @options.gitignore_config_file
-            }
-
-            config_files.each do |name, path|
-              raise(GHB::ConfigError, "Missing required #{name} file: #{path}") unless File.exist?(path)
-
-              begin
-                Psych.safe_load(File.read(path), permitted_classes: [Symbol])
-              rescue Psych::SyntaxError => e
-                raise(GHB::ConfigError, "Invalid YAML in #{name} file (#{path}): #{e.message}")
-              end
-            end
-          end
-        end
-
-      config_app = absolute_path_test_class.new(temp_options)
-
       expect { config_app.validate_config! }
-        .to(raise_error(GHB::ConfigError, /Invalid YAML in languages config file/))
+        .to(raise_error(GHB::ConfigError, %r{Invalid YAML in languages config file \(config/languages\.yaml\)}))
     end
 
     it 'raises ConfigError when a linter entry is missing required keys' do # rubocop:disable RSpec/ExampleLength

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -298,6 +298,30 @@ RSpec.describe(GHB::GitHubAPIClient) do
       expect(client).to(have_received(:sleep).with(7))
     end
 
+    it 'honors the X-RateLimit-Reset header (reset minus now) for the back-off' do # rubocop:disable RSpec/ExampleLength
+      now = 1_700_000_000
+      allow(Time).to(receive(:now).and_return(Time.at(now)))
+      stub_request(:get, base_url)
+        .to_return(status: 429, headers: { 'X-RateLimit-Reset': (now + 5).to_s }, body: '{}')
+        .then.to_return(status: 200, body: '{"ok":true}')
+
+      client.get(base_url)
+
+      expect(client).to(have_received(:sleep).with(5))
+    end
+
+    it 'caps the X-RateLimit-Reset back-off at MAX_RETRY_WAIT (60s)' do # rubocop:disable RSpec/ExampleLength
+      now = 1_700_000_000
+      allow(Time).to(receive(:now).and_return(Time.at(now)))
+      stub_request(:get, base_url)
+        .to_return(status: 429, headers: { 'X-RateLimit-Reset': (now + 9999).to_s }, body: '{}')
+        .then.to_return(status: 200, body: '{"ok":true}')
+
+      client.get(base_url)
+
+      expect(client).to(have_received(:sleep).with(60))
+    end
+
     it 'does not treat a plain 403 (no rate-limit header) as retryable' do # rubocop:disable RSpec/MultipleExpectations
       stub_request(:get, base_url)
         .to_return(status: 403, body: '{"message":"Forbidden"}')


### PR DESCRIPTION
## Summary

Resolves the two remaining code-review test-coverage findings, **F2** and **F3**. Test-only change — no production code is modified.

**F2** — `spec/ghb/application_spec.rb`: the "raises ConfigError when a config file has invalid YAML" test previously defined a parallel `absolute_path_test_class` that *reimplemented* the validation logic and asserted against the copy. The real `Application#validate_config!` `Psych::SyntaxError` rescue (`application.rb:156`) was never executed by any test, so a regression there would not be caught. The test now drives the real `validate_config!` (via the existing `config_test_class`) and wraps `cached_file_read` so only the languages config returns malformed YAML — the valid linters config is parsed first from the real on-disk file, then the malformed languages config triggers the real rescue. The now-unused `temp_dir` `let` and its `after` cleanup hook are removed.

**F3** — `spec/ghb/git_hub_api_client_spec.rb`: the retry suite covered `Retry-After`, 429, and 403 + secondary-limit, but never set `X-RateLimit-Reset`, so the `reset - Time.now.to_i` math and the `MAX_RETRY_WAIT` (60s) cap — the explicit safeguard so a far-future reset can't hang CI — were untested. Added two specs with a frozen clock: one asserting a near-future reset sleeps for the computed delta, one asserting a far-future reset is clamped to 60s.

**Key changes:**

- `spec/ghb/application_spec.rb`: replace the reimplemented validation test with one exercising the real `validate_config!` + real `Psych::SyntaxError` rescue; drop the now-unused `temp_dir`/`after` scaffolding
- `spec/ghb/git_hub_api_client_spec.rb`: add `X-RateLimit-Reset` reset-math test and `MAX_RETRY_WAIT` cap test
- Full suite: 341 examples, 0 failures; RuboCop 0 offenses; coverage rose to 98.66% line / 87.58% branch (previously-uncovered rescue and rate-limit paths now exercised)

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
