### PR TITLE
Drop unused packages:write from generated docker.yml (least-privilege)

### DIFF
--- a/lib/ghb/dockerhub_manager.rb
+++ b/lib/ghb/dockerhub_manager.rb
@@ -23,9 +23,14 @@ module GHB
       @dockerhub_workflow.do_job(:push_to_registry) do
         do_name('Push Docker Image to Docker Hub')
         do_runs_on(DEFAULT_UBUNTU_VERSION)
+        # Permission scopes are the minimum required by cloud-officer/ci-actions/docker@v2:
+        # - contents:read     for actions/checkout
+        # - id-token:write    for actions/attest-build-provenance OIDC signing via Sigstore
+        # - attestations:write for publishing the build provenance attestation to GitHub
+        # Docker Hub push itself authenticates via DOCKER_USERNAME / DOCKER_PASSWORD,
+        # so packages:write (which is for GHCR) is intentionally NOT requested here.
         do_permissions(
           {
-            packages: 'write',
             contents: 'read',
             attestations: 'write',
             'id-token': 'write'

--- a/spec/ghb/dockerhub_manager_spec.rb
+++ b/spec/ghb/dockerhub_manager_spec.rb
@@ -26,7 +26,13 @@ RSpec.describe(GHB::DockerhubManager) do
       expect(workflow.on).to(eq({ push: { tags: %w[**] } }))
       expect(workflow.jobs).to(have_key(:push_to_registry))
       expect(workflow.jobs[:push_to_registry].name).to(eq('Push Docker Image to Docker Hub'))
-      expect(workflow.jobs[:push_to_registry].permissions).to(include(packages: 'write'))
+      # Regression test for CI-01 (soup#docs/code-review.md): packages:write is for
+      # GHCR; cloud-officer/ci-actions/docker@v2 pushes to Docker Hub via
+      # DOCKER_USERNAME/DOCKER_PASSWORD and never touches GHCR, so the scope must
+      # NOT be requested. attestations:write and id-token:write are required by
+      # actions/attest-build-provenance, so they stay.
+      expect(workflow.jobs[:push_to_registry].permissions).to(eq(contents: 'read', attestations: 'write', 'id-token': 'write'))
+      expect(workflow.jobs[:push_to_registry].permissions).not_to(include(packages: 'write'))
       expect(workflow.jobs[:push_to_registry].steps.length).to(eq(1))
       expect(workflow.jobs[:push_to_registry].steps.first.name).to(eq('Publish Docker image'))
     end


### PR DESCRIPTION
## Summary

Surfaced by the soup repo's `docs/code-review.md` (finding CI-01). The Docker Hub workflow that this generator emits via `DockerhubManager` requested four permission scopes on every consumer repo, but only three are actually used. `cloud-officer/ci-actions/docker@v2`:

- Step 1 (`actions/checkout`) — needs `contents: read`.
- Step 7 (`actions/attest-build-provenance@v3`) — needs `id-token: write` for Sigstore OIDC signing and `attestations: write` to publish the attestation.
- The Docker Hub push itself authenticates with `DOCKER_USERNAME` / `DOCKER_PASSWORD`, never with `GITHUB_TOKEN`. It does not touch GHCR.

That means `packages: write` (the GHCR scope) was unused on every repo with a `.dockerhub` marker. Dropping it is a small attack-surface reduction: a compromise of the floating `@v2` tag could otherwise have used the token to publish a malicious image to `ghcr.io/<org>/<repo>` under each consumer org's namespace.

**Key changes:**

- `lib/ghb/dockerhub_manager.rb` — drop `packages: 'write'` from the `do_permissions` hash. Added a comment block enumerating which sub-action consumes each remaining scope so future maintainers don't re-add it.
- `spec/ghb/dockerhub_manager_spec.rb` — flipped the existing assertion to verify the exact permissions hash and added a `not_to(include(packages: 'write'))` regression guard with a reference back to the soup finding.

Full RSpec suite: 347 examples, 0 failures, line coverage 98.86%, branch 87.75%. RuboCop clean on touched files.

Downstream effect: next regeneration of any consumer repo's `.github/workflows/docker.yml` (e.g. soup) will pick up the tightened permissions automatically.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified