### PR TITLE
Bound GitHub API client requests with open and read timeouts

### DIFF
--- a/lib/ghb/github_api_client.rb
+++ b/lib/ghb/github_api_client.rb
@@ -13,10 +13,16 @@ module GHB
     MAX_RETRIES = 3
     # Cap a single rate-limit back-off so a far-future X-RateLimit-Reset can't hang CI.
     MAX_RETRY_WAIT = 60
+    # Bound every request so a stalled connection can't hang the CLI indefinitely
+    # (and so the Net::OpenTimeout / Net::ReadTimeout retry path can actually fire).
+    OPEN_TIMEOUT = 10
+    READ_TIMEOUT = 30
     RETRYABLE_ERRORS = [Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError].freeze
 
     private_constant :MAX_RETRIES
     private_constant :MAX_RETRY_WAIT
+    private_constant :OPEN_TIMEOUT
+    private_constant :READ_TIMEOUT
     private_constant :RETRYABLE_ERRORS
 
     def initialize(token)
@@ -45,7 +51,7 @@ module GHB
     private
 
     def execute(method, url, body: nil, headers: {}, expected_codes: [200])
-      options = { headers: @headers.merge(headers) }
+      options = { headers: @headers.merge(headers), open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT }
       options[:body] = body.to_json if body
 
       response = with_retries { HTTParty.public_send(method, url, options) }

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe(GHB::GitHubAPIClient) do
       response = client.get(base_url, expected_codes: nil)
       expect(response.code).to(eq(403))
     end
+
+    it 'bounds every request with open and read timeouts' do
+      allow(HTTParty).to(receive(:get).and_return(instance_double(HTTParty::Response, code: 200, body: '{}')))
+
+      client.get(base_url)
+
+      expect(HTTParty).to(have_received(:get).with(base_url, hash_including(open_timeout: 10, read_timeout: 30)))
+    end
   end
 
   describe '#put' do


### PR DESCRIPTION
## Summary

`GitHubAPIClient#execute` issued every request through HTTParty without an open or read timeout, so a stalled connection on any of the ~15 sequential calls made during repository configuration could hang the CLI indefinitely with no feedback. The sibling `GitignoreManager` already passes `timeout: 30` to the same library, so the omission was an inconsistency rather than a deliberate choice. As a side effect, the existing `Net::OpenTimeout` / `Net::ReadTimeout` entries in `RETRYABLE_ERRORS` could never fire, because those exceptions are only raised when a timeout is configured.

**Key changes:**

- Add `OPEN_TIMEOUT` (10s) and `READ_TIMEOUT` (30s) private constants to `GitHubAPIClient`.
- Pass both timeouts on every request built in `execute`, activating the existing timeout-retry path.
- Add a spec asserting that requests are bounded with the open and read timeouts.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified