### PR TITLE
Correct generated workflow filename in architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@
 |   build.yml       |
 |   dependencies.yml|
 |   docker.yml      |
-|   auto-merge.yml  |
+|   auto-approve.yml|
 | .gitignore        |
 | Linter configs    |
 +-------------------+
@@ -364,7 +364,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 **Key Components:**
 
 - `initialize(auto_merge_workflow:)`: Accepts auto-merge workflow object
-- `save`: Configures the auto-merge workflow with CODEOWNERS detection and auto-approval, and writes `.github/workflows/auto-merge.yml`. The CODEOWNERS membership check uses `GH_PAT`, while the approval step uses `GH_BOT_PAT` so the bot identity satisfies the `require_code_owner_reviews` branch-protection rule
+- `save`: Configures the auto-approve workflow with CODEOWNERS detection and auto-approval, and writes `.github/workflows/auto-approve.yml` (removing the legacy `auto-merge.yml` if present). The CODEOWNERS membership check uses `GH_PAT`, while the approval step uses `GH_BOT_PAT` so the bot identity satisfies the `require_code_owner_reviews` branch-protection rule
 
 ### GHB::DependabotManager
 
@@ -457,7 +457,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 - `initialize(name)`: Creates workflow with name
 - `read(file)`: Parses existing workflow YAML file
-- `write(file, header:)`: Writes workflow to YAML file, applying two transformations via `rewrite_github_refs`: rewrites `${GITHUB_*}` references to `${{github.*}}` in YAML values while preserving them in shell `run:` bodies (where they are runner-exported env vars), and substitutes `${{secrets.GITHUB_TOKEN}}` with `${{secrets.GH_PAT}}` for higher rate limits (except in the auto-merge workflow)
+- `write(file, header:)`: Writes workflow to YAML file, applying two transformations via `rewrite_github_refs`: rewrites `${GITHUB_*}` references to `${{github.*}}` in YAML values while preserving them in shell `run:` bodies (where they are runner-exported env vars), and substitutes `${{secrets.GITHUB_TOKEN}}` with `${{secrets.GH_PAT}}` for higher rate limits (except in the auto-approve workflow)
 - `do_job(id, &block)`: DSL method to define jobs
 - `to_h`: Converts workflow to hash for YAML serialization
 


### PR DESCRIPTION
## Summary

`docs/architecture.md` still referred to a generated workflow named `auto-merge.yml`, but `AutoMergeManager` now writes `.github/workflows/auto-approve.yml` and removes the legacy `auto-merge.yml` on regeneration (the rename landed in commit fdc14ed). This corrects the stale filename so the documentation matches the code the tool actually emits.

**Key changes:**

- Update the "Output Files" diagram to list `auto-approve.yml` instead of `auto-merge.yml`.
- Fix the `AutoMergeManager#save` description to state it writes `auto-approve.yml` (and removes the legacy `auto-merge.yml` if present).
- Align the `Workflow#write` token-rewrite note to say "auto-approve workflow".

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; no code paths affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified