### PR TITLE
#405: tighten auto-approve.yml workflow permissions to contents: read

### DIFF
--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -72,11 +72,12 @@ module GHB
             }
         }
 
+      # Least privilege: the only GITHUB_TOKEN consumer is actions/checkout (base SHA),
+      # which needs contents: read. Both gh steps authenticate via GH_PAT / GH_BOT_PAT,
+      # so the workflow token needs no write scopes.
       @auto_merge_workflow.permissions =
         {
-          contents: 'write',
-          'pull-requests': 'write',
-          issues: 'write'
+          contents: 'read'
         }
 
       # Cancel superseded runs on rapid pushes to the same PR.

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -41,16 +41,14 @@ RSpec.describe(GHB::AutoMergeManager) do
       )
     end
 
-    it 'sets the correct permissions' do # rubocop:disable RSpec/ExampleLength
+    it 'sets least-privilege permissions (contents: read only)' do # rubocop:disable RSpec/ExampleLength
       manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
       manager.save
 
       expect(auto_merge_workflow.permissions).to(
         eq(
           {
-            contents: 'write',
-            'pull-requests': 'write',
-            issues: 'write'
+            contents: 'read'
           }
         )
       )


### PR DESCRIPTION
## Summary

The auto-generated `.github/workflows/auto-approve.yml` (produced by `AutoMergeManager`) declared broader workflow-level permissions than any step uses. The only `GITHUB_TOKEN` consumer is `actions/checkout` checking out the base SHA, which needs `contents: read`; the two `gh` steps authenticate via `secrets.GH_PAT` / `secrets.GH_BOT_PAT`, so the workflow token's `pull-requests: write`, `issues: write`, and the `write` half of `contents` were all unused. This tightens the emitted block to `contents: read` as a least-privilege / defense-in-depth improvement, with no behavioral change.

**Key changes:**

- `lib/ghb/auto_merge_manager.rb`: emit `permissions: { contents: read }` for the generated `auto-approve.yml`, with a comment explaining why no write scopes are needed.
- `spec/ghb/auto_merge_manager_spec.rb`: update the permissions assertion to expect `contents: read` only.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified