### PR TITLE
#406: declare workflow-level permissions default in generated docker.yml

### DIFF
--- a/lib/ghb/dockerhub_manager.rb
+++ b/lib/ghb/dockerhub_manager.rb
@@ -20,6 +20,15 @@ module GHB
             }
         }
 
+      # Workflow-level least-privilege default. The single job below opts into the
+      # write scopes it needs; declaring contents: read here forces any job added
+      # later to request write scopes deliberately rather than inheriting the
+      # repository's (often broader) default GITHUB_TOKEN permissions.
+      @dockerhub_workflow.permissions =
+        {
+          contents: 'read'
+        }
+
       @dockerhub_workflow.do_job(:push_to_registry) do
         do_name('Push Docker Image to Docker Hub')
         do_runs_on(DEFAULT_UBUNTU_VERSION)

--- a/spec/ghb/dockerhub_manager_spec.rb
+++ b/spec/ghb/dockerhub_manager_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe(GHB::DockerhubManager) do
       manager.save
 
       expect(workflow.on).to(eq({ push: { tags: %w[**] } }))
+      # Workflow-level least-privilege default so any future job must opt into
+      # write scopes rather than inheriting the repo's default GITHUB_TOKEN scope.
+      expect(workflow.permissions).to(eq(contents: 'read'))
       expect(workflow.jobs).to(have_key(:push_to_registry))
       expect(workflow.jobs[:push_to_registry].name).to(eq('Push Docker Image to Docker Hub'))
       # Regression test for CI-01 (soup#docs/code-review.md): packages:write is for


### PR DESCRIPTION
## Summary

The auto-generated `.github/workflows/docker.yml` declared `permissions:` only at the job level. The single existing job is fine as-is, but if a second job were ever added (by `github-build` or a hand-edit in a consumer repo) without its own `permissions:` block, that job would inherit the repository's default `GITHUB_TOKEN` scope, which is often broader than `contents: read`. This adds an explicit workflow-level `contents: read` baseline so any future job must opt into write scopes deliberately. No behavioral change to the existing single job.

**Key changes:**

- `lib/ghb/dockerhub_manager.rb`: emit a workflow-level `permissions: { contents: read }` block for the generated `docker.yml`, with a comment explaining the future-proofing rationale.
- `spec/ghb/dockerhub_manager_spec.rb`: assert the workflow-level permissions default.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified