### PR TITLE
Fix #410: scope GH_PAT insteadOf rewrites to repository owner in dependencies.yml

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -46,11 +46,16 @@ module GHB
       @required_status_checks = []
       @submodules = []
       @unit_tests_conditions = nil
+      # Scope the PAT insteadOf rewrites to the owning org only. A bare
+      # github.com/ rewrite would attach GH_PAT to ANY github.com URL fetched
+      # later in the run (transitive git-source gems on bundle update, etc.);
+      # narrowing to ${{github.repository_owner}}/ limits the token to this
+      # org's own repos and shrinks the exfiltration surface. See CI-004 (#410).
       @dependencies_commands =
         <<~BASH
-          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/".insteadOf ssh://git@github.com:
-          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/".insteadOf https://github.com/
-          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/".insteadOf git@github.com:
+          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/${{github.repository_owner}}/".insteadOf ssh://git@github.com:${{github.repository_owner}}/
+          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/${{github.repository_owner}}/".insteadOf https://github.com/${{github.repository_owner}}/
+          git config --global --add url."https://${GH_PAT}:x-oauth-basic@github.com/${{github.repository_owner}}/".insteadOf git@github.com:${{github.repository_owner}}/
 
         BASH
     end

--- a/spec/ghb/application_spec.rb
+++ b/spec/ghb/application_spec.rb
@@ -158,6 +158,20 @@ RSpec.describe(GHB::Application) do
     end
   end
 
+  describe 'dependencies git-config rewrite (CI-004)' do
+    subject(:dependencies_commands) { described_class.new([]).instance_variable_get(:@dependencies_commands) }
+
+    it 'scopes every GH_PAT insteadOf rewrite to the repository owner' do # rubocop:disable RSpec/MultipleExpectations
+      expect(dependencies_commands).to(include('.insteadOf https://github.com/${{github.repository_owner}}/'))
+      expect(dependencies_commands).to(include('.insteadOf git@github.com:${{github.repository_owner}}/'))
+      expect(dependencies_commands).to(include('.insteadOf ssh://git@github.com:${{github.repository_owner}}/'))
+    end
+
+    it 'does not attach the PAT to unscoped github.com URLs' do
+      expect(dependencies_commands).not_to(include(".insteadOf https://github.com/\n"))
+    end
+  end
+
   describe 'private internals' do
     let(:internals_class) do
       Class.new(described_class) do


### PR DESCRIPTION
## Summary

The generated `dependencies.yml` configured three global `git config insteadOf` rewrites that attached `GH_PAT` to **any** `github.com` URL (`https://github.com/`, `git@github.com:`, `ssh://git@github.com:`). Any step running after that block — a transitive git-source gem on `bundle update`, a tampered action — could cause the PAT to be sent to arbitrary github.com URLs on the runner.

This applies suggested fix #3 from the issue: narrow all three rewrites to the owning org (`https://github.com/${{github.repository_owner}}/` and the ssh/scp equivalents), so the token is only ever attached to the org's own repos. The PAT itself is unchanged — it is required by design (a `GITHUB_TOKEN`-opened PR cannot trigger downstream CI). `Closes #410`.

**Key changes:**

- `lib/ghb/application.rb`: scope the three `insteadOf` rewrites in `@dependencies_commands` to `${{github.repository_owner}}/` instead of bare `github.com`.
- `spec/ghb/application_spec.rb`: add a regression test asserting every rewrite is owner-scoped and no unscoped `github.com/` rewrite remains.

Verified by rendering the generated `dependencies.yml`: `${{github.repository_owner}}` is preserved in the `run:` body (interpolated to the org slug at runtime).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

Closes #410