### PR TITLE
Harden linter configs: disable risky RuboCop cop, ignore coverage in ESLint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,11 @@ Style/TopLevelMethodDefinition:
   Enabled: false
 Style/YodaExpression:
   Enabled: false
+# Autocorrect for this cop collapses multi-line method signatures and can drop
+# inline `# rubocop:disable` directives in the process. See:
+# https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+Style/MultilineMethodSignature:
+  Enabled: false
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 Minitest/NoTestCases:

--- a/config/linters/.eslintrc.json
+++ b/config/linters/.eslintrc.json
@@ -3,7 +3,7 @@
     "node": true,
     "es2021": true
   },
-  "ignorePatterns": ["**/dist/**", "**/vendor/**", "**/node_modules/**", "**/Libraries/**", "**/Pods/**", "**/.build/**", "**/Carthage/**", "**/DerivedData/**", "**/venv/**", "**/.venv/**", "**/build/**", "**/target/**"],
+  "ignorePatterns": ["**/dist/**", "**/vendor/**", "**/node_modules/**", "**/Libraries/**", "**/Pods/**", "**/.build/**", "**/Carthage/**", "**/DerivedData/**", "**/venv/**", "**/.venv/**", "**/build/**", "**/target/**", "**/coverage/**"],
   "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": "latest",

--- a/config/linters/.rubocop.yml
+++ b/config/linters/.rubocop.yml
@@ -68,6 +68,11 @@ Style/TopLevelMethodDefinition:
   Enabled: false
 Style/YodaExpression:
   Enabled: false
+# Autocorrect for this cop collapses multi-line method signatures and can drop
+# inline `# rubocop:disable` directives in the process. See:
+# https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+Style/MultilineMethodSignature:
+  Enabled: false
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 Minitest/NoTestCases:


### PR DESCRIPTION
## Summary

These changes harden the shared linter configurations used across builds. The RuboCop `Style/MultilineMethodSignature` cop is disabled in both the root and `config/linters` copies because its autocorrect collapses multi-line method signatures and can silently drop inline `# rubocop:disable` directives. The ESLint config now ignores `**/coverage/**` so generated coverage reports are no longer linted.

**Key changes:**

- Disable `Style/MultilineMethodSignature` in `.rubocop.yml` and `config/linters/.rubocop.yml`, with a comment linking to the cop docs that explains the autocorrect risk
- Add `**/coverage/**` to the ESLint `ignorePatterns` in `config/linters/.eslintrc.json`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Linter configuration changes (YAML/JSON) are not unit-testable.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified