### PR TITLE
Fix RuboCop uncommenting to preserve prose comments in Rails projects

### DIFF
--- a/lib/ghb/linter_job_builder.rb
+++ b/lib/ghb/linter_job_builder.rb
@@ -120,9 +120,11 @@ module GHB
       else
         # Use atomic file operation to prevent data loss if copy fails
         atomic_copy_config("#{__dir__}/../../config/linters/#{linter[:config]}", linter[:config]) do |content|
-          # Uncomment Rails-specific rules if this is a Rails project
+          # Uncomment Rails-specific rules if this is a Rails project. Only
+          # un-comment commented-out YAML config (list items and mapping keys)
+          # so prose comments (e.g. the MultilineMethodSignature note) survive.
           if linter[:config] == '.rubocop.yml' && File.exist?('Gemfile') && File.read('Gemfile').include?('rails')
-            content.gsub(/^(\s*)# /, '\1')
+            content.gsub(/^(\s*)# (?=\s*(?:-\s|[^\s:#]+:(?:\s|$)))/, '\1')
           else
             content
           end

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -377,6 +377,64 @@ RSpec.describe(GHB::LinterJobBuilder) do
         # The transformation block should have uncommented the Rails rules
         expect(File).to(have_received(:write).with(anything, "AllCops:\n  TargetRailsVersion: 7.0\n"))
       end
+
+      it 'leaves prose comments commented while uncommenting Rails config' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        allow(File).to(receive(:exist?).and_call_original)
+        allow(File).to(receive(:exist?).with('.gitmodules').and_return(false))
+
+        builder = described_class.new(
+          context: GHB::BuildContext.new(
+            options: options,
+            submodules: submodules,
+            old_workflow: old_workflow,
+            new_workflow: new_workflow,
+            file_cache: file_cache
+          )
+        )
+
+        # Only match rubocop pattern (Fastfile)
+        allow(builder).to(receive(:find_files_matching).and_return([]))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('Fastfile')), anything).and_return(['Fastfile']))
+
+        # No script_path, no preserve_config -> falls through to atomic_copy_config
+        allow(File).to(receive(:exist?).with('/linters/.rubocop.yml').and_return(false))
+        allow(File).to(receive(:exist?).with('.rubocop.yml').and_return(false))
+
+        # Rails project detection
+        allow(File).to(receive(:exist?).with('Gemfile').and_return(true))
+        allow(File).to(receive(:read).and_call_original)
+        allow(File).to(receive(:read).with('Gemfile').and_return("gem 'rails'\n"))
+
+        # Prose comment lines (no key:, or a URL whose colon isn't a YAML key)
+        # must survive; commented config keys/list items must be uncommented.
+        rubocop_content = <<~RUBOCOP
+          # Autocorrect for this cop collapses signatures. See:
+          # https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+          Style/MultilineMethodSignature:
+            Enabled: false
+          # Rails/EnvironmentVariableAccess:
+          #   Exclude:
+          #     - "app/jobs/**/*"
+        RUBOCOP
+        expected = <<~RUBOCOP
+          # Autocorrect for this cop collapses signatures. See:
+          # https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+          Style/MultilineMethodSignature:
+            Enabled: false
+          Rails/EnvironmentVariableAccess:
+            Exclude:
+              - "app/jobs/**/*"
+        RUBOCOP
+        allow(File).to(receive(:read).with(%r{config/linters/\.rubocop\.yml}).and_return(rubocop_content))
+        allow(File).to(receive(:write))
+        allow(FileUtils).to(receive(:mv))
+
+        builder.build
+
+        expect(new_workflow.jobs).to(have_key(:rubocop))
+        expect(YAML.safe_load(expected)).to(be_a(Hash)) # expected output is valid YAML
+        expect(File).to(have_received(:write).with(anything, expected))
+      end
     end
 
     context 'when linter is not enabled (no matches) and has a config file' do


### PR DESCRIPTION
## Summary

When generating a Rails project's `.rubocop.yml`, the linter job builder
uncomments the Rails-specific rules that ship commented out in the bundled
config. The previous implementation uncommented every `# `-prefixed line,
which also stripped legitimate prose comments (for example, the explanatory
note above the `Style/MultilineMethodSignature` cop). This narrows the
transformation so only commented-out YAML is uncommented, leaving human
notes intact.

**Key changes:**

- Narrow the uncomment regex in `lib/ghb/linter_job_builder.rb` to use a
  lookahead that matches `# ` only when it precedes a YAML list item (`- `)
  or a mapping key (`key:`), so prose comments are preserved.
- Add a spec in `spec/ghb/linter_job_builder_spec.rb` that asserts prose
  comments stay commented while Rails config keys and list items are
  uncommented for a Rails project.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
