### PR TITLE
Skip self-approval in generated auto-approve workflow

### DIFF
--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -55,7 +55,23 @@ module GHB
       echo "PR author ${AUTHOR} is_owner=${is_owner}"
     BASH
 
-    private_constant :OLD_WORKFLOW_FILE, :WORKFLOW_FILE, :CODEOWNERS_CHECK_SCRIPT
+    # Bash run by the "Approve PR" step. GitHub rejects approving your own PR, so
+    # when GH_BOT_PAT resolves to the same account that opened the PR (e.g. the
+    # dependency-update bot approving its own PRs) we skip instead of failing the
+    # job. Human code-owner PRs (author != bot) are still approved as before.
+    APPROVE_SCRIPT = <<~BASH
+      set -euo pipefail
+
+      APPROVER=$(gh api user --jq .login)
+      if [ "$APPROVER" = "$AUTHOR" ]; then
+        echo "Approver $APPROVER is the PR author; skipping self-approval."
+        exit 0
+      fi
+
+      gh pr review --approve "$PR"
+    BASH
+
+    private_constant :OLD_WORKFLOW_FILE, :WORKFLOW_FILE, :CODEOWNERS_CHECK_SCRIPT, :APPROVE_SCRIPT
 
     def initialize(auto_merge_workflow:)
       @auto_merge_workflow = auto_merge_workflow
@@ -122,10 +138,11 @@ module GHB
           do_env(
             {
               GH_TOKEN: '${{secrets.GH_BOT_PAT}}',
+              AUTHOR: '${{github.event.pull_request.user.login}}',
               PR: '${{github.event.pull_request.number}}'
             }
           )
-          do_run('gh pr review --approve "$PR"')
+          do_run(APPROVE_SCRIPT)
         end
       end
 

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -126,8 +126,18 @@ RSpec.describe(GHB::AutoMergeManager) do
       approve_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name == 'Approve PR' }
       expect(approve_step).not_to(be_nil)
       expect(approve_step.if).to(eq("steps.check.outputs.is_owner == 'true'"))
-      expect(approve_step.run).to(eq('gh pr review --approve "$PR"'))
+      expect(approve_step.run).to(include('gh pr review --approve "$PR"'))
       expect(approve_step.env[:GH_TOKEN]).to(eq('${{secrets.GH_BOT_PAT}}'))
+      expect(approve_step.env[:AUTHOR]).to(eq('${{github.event.pull_request.user.login}}'))
+    end
+
+    it 'skips self-approval when the approver is the PR author' do # rubocop:disable RSpec/MultipleExpectations
+      manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
+      manager.save
+
+      approve_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name == 'Approve PR' }
+      expect(approve_step.run).to(include('APPROVER=$(gh api user --jq .login)'))
+      expect(approve_step.run).to(include('skipping self-approval'))
     end
 
     it 'does not include a merge step' do


### PR DESCRIPTION
## Summary

The generated `auto-approve.yml` workflow approves code-owner PRs with `gh pr review --approve` using `secrets.GH_BOT_PAT`. When that token resolves to the same GitHub account that opened the PR — e.g. the weekly dependency-update bot, which creates its PR under the same identity via `secrets.GH_PAT` — GitHub rejects the review with `Can not approve your own pull request` and the job fails on every such PR.

This adds a guard to the "Approve PR" step that resolves the approver's own login (`gh api user --jq .login`) and skips (exit 0) when it equals the PR author, so the workflow no longer fails on self-authored PRs. Human code-owner PRs (author != bot) are still approved exactly as before.

**Key changes:**

- `lib/ghb/auto_merge_manager.rb`: add an `APPROVE_SCRIPT` that compares the approver's login to the PR author and skips self-approval; pass `AUTHOR` into the "Approve PR" step env.
- `spec/ghb/auto_merge_manager_spec.rb`: assert the new `AUTHOR` env and add a test covering the self-approval skip.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
