### PR TITLE
Generate Vercel deploy jobs (beta/rc/prod) and preserve custom alias steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ root. No CLI flags are needed for these; they are detected on every run.
 | ---------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `.aws` | Adds an AWS commands job to the workflow | Remove the `.aws` file |
 | `appspec.yml` | Adds CodeDeploy and environment deployment jobs (`beta_deploy`, `rc_deploy`, `prod_deploy`) | Remove `appspec.yml` |
+| `vercel.json` (or a `"vercel"`/`"next"` dependency in `package.json`) | Adds Vercel deployment jobs (`beta_deploy`, `rc_deploy`, `prod_deploy`) driving the Vercel CLI. Ignored when `appspec.yml` is present (CodeDeploy wins). Custom steps such as `vercel alias` are preserved across regenerations | Remove `vercel.json` and the `vercel`/`next` dependency |
 | `.dockerhub` | Generates a separate Docker Hub workflow (`.github/workflows/docker.yml`) that pushes images on tag events | Remove the `.dockerhub` file |
 | `ci_scripts/` | Adds `Xcode` to the expected branch protection status checks | Remove the `ci_scripts/` directory |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,10 @@
 +------------------------------------------------------------------------+
 |                         Job Builders & Managers                         |
 |  VariablesJobBuilder  |  LinterJobBuilder    |  LicensesJobBuilder    |
-|  LanguageJobBuilder   |  CodeDeployJobBuilder|  AwsJobBuilder         |
-|  SlackJobBuilder      |  DependabotManager   |  DockerhubManager      |
-|  AutoMergeManager     |  GitignoreManager    |  RepositoryConfigurator|
+|  LanguageJobBuilder   |  CodeDeployJobBuilder|  VercelJobBuilder      |
+|  AwsJobBuilder        |  SlackJobBuilder     |  DependabotManager     |
+|  DockerhubManager     |  AutoMergeManager    |  GitignoreManager      |
+|  RepositoryConfigurator|                     |                        |
 +------------------------------------------------------------------------+
          |  uses                       |  uses
          v                             v
@@ -65,7 +66,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 1. The CLI entry point (`bin/github-build.rb`) instantiates `GHB::Application`
 2. `Application` parses command-line options via `GHB::Options` and validates configuration
 3. `Application` bundles the shared inputs (options, old/new workflow, file cache, submodules) into an immutable `GHB::BuildContext` that is passed to every builder
-4. `Application` delegates workflow generation to specialized builders: `VariablesJobBuilder`, `LinterJobBuilder`, `LicensesJobBuilder`, `LanguageJobBuilder`, `CodeDeployJobBuilder`, `AwsJobBuilder`, and `SlackJobBuilder`
+4. `Application` delegates workflow generation to specialized builders: `VariablesJobBuilder`, `LinterJobBuilder`, `LicensesJobBuilder`, `LanguageJobBuilder`, `CodeDeployJobBuilder`, `VercelJobBuilder`, `AwsJobBuilder`, and `SlackJobBuilder`
 5. Post-generation managers handle output: `DependabotManager`, `AutoMergeManager`, `DockerhubManager`, `GitignoreManager`, and `RepositoryConfigurator`
 6. `GitignoreManager` delegates pure rule logic (template detection, content transforms) to `GHB::GitignoreRules`
 7. `FileScanner` mixin provides shared pure-Ruby file operations to builders that need file pattern matching
@@ -139,6 +140,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `GHB::LicensesJobBuilder`
 - `GHB::LanguageJobBuilder`
 - `GHB::CodeDeployJobBuilder`
+- `GHB::VercelJobBuilder`
 - `GHB::AwsJobBuilder`
 - `GHB::SlackJobBuilder`
 - `GHB::DependabotManager`
@@ -334,6 +336,17 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 - `initialize(context:, code_deploy_pre_steps:)`: Accepts a `GHB::BuildContext` and the collected pre-deployment steps
 - `build`: Creates CodeDeploy packaging and per-environment deployment jobs
+
+### GHB::VercelJobBuilder
+
+**Purpose:** Builds the Vercel `beta_deploy` / `rc_deploy` / `prod_deploy` jobs — the Vercel counterpart to `CodeDeployJobBuilder`. Triggered when a `vercel.json` marker is present or `package.json` declares a `"vercel"` / `"next"` dependency. CodeDeploy takes precedence: when `appspec.yml` exists these jobs are left to `CodeDeployJobBuilder` so the `*_deploy` job names do not collide.
+
+**Location:** `lib/ghb/vercel_job_builder.rb`
+
+**Key Components:**
+
+- `initialize(context:)`: Accepts a `GHB::BuildContext`
+- `build`: Creates the three per-environment Vercel CLI deploy jobs (`prod` publishes with `--prod`; `beta`/`rc` deploy a preview build and capture the URL). Generated steps are Setup, Install Vercel CLI, Pull Vercel Environment Information, and Deploy Project to Vercel; any other step on an existing `*_deploy` job (e.g. project-specific `vercel alias` steps) is preserved across regenerations.
 
 ### GHB::AwsJobBuilder
 

--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -24,6 +24,7 @@ require_relative 'repository_configurator'
 require_relative 'slack_job_builder'
 require_relative 'status'
 require_relative 'variables_job_builder'
+require_relative 'vercel_job_builder'
 require_relative 'workflow/workflow'
 
 module GHB
@@ -100,6 +101,8 @@ module GHB
       collect_required_status_checks
 
       CodeDeployJobBuilder.new(context: context, code_deploy_pre_steps: @code_deploy_pre_steps).build
+
+      VercelJobBuilder.new(context: context).build
 
       AwsJobBuilder.new(context: context).build
       SlackJobBuilder.new(context: context).build

--- a/lib/ghb/vercel_job_builder.rb
+++ b/lib/ghb/vercel_job_builder.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+module GHB
+  # Builds the Vercel deploy jobs (beta_deploy / rc_deploy / prod_deploy).
+  #
+  # This is the Vercel counterpart to CodeDeployJobBuilder: where an appspec.yml
+  # repo gets AWS CodeDeploy *_deploy jobs, a Vercel repo gets *_deploy jobs that
+  # drive the Vercel CLI. A repo is treated as Vercel when a vercel.json marker
+  # file is present, or its package.json declares a "vercel" or "next"
+  # dependency.
+  #
+  # CodeDeploy takes precedence: when appspec.yml exists these jobs are left to
+  # CodeDeployJobBuilder so the *_deploy job names do not collide.
+  #
+  # Each job emits four generated steps (Setup, Install Vercel CLI, Pull Vercel
+  # Environment Information, Deploy Project to Vercel). Any other step found on an
+  # existing *_deploy job - typically project-specific `vercel alias ...` steps,
+  # whose domains the generator cannot know - is preserved and appended, so
+  # regeneration stops stripping them (the bug the pnp-web-next hotfix worked
+  # around).
+  class VercelJobBuilder
+    # Generated deploy jobs: environment key => display name + Vercel CLI target.
+    # prod publishes with `--prod`; beta and rc deploy a preview build and
+    # capture the resulting URL so preserved alias steps can reference it via
+    # steps.deploy.outputs.url. "RC" is upper-cased to match the hand-written
+    # Vercel template (CodeDeploy's equivalent reads "Rc Deploy").
+    DEPLOYS = {
+      beta: { name: 'Beta Deploy', target: 'preview' },
+      rc: { name: 'RC Deploy', target: 'preview' },
+      prod: { name: 'Prod Deploy', target: 'production' }
+    }.freeze
+    private_constant :DEPLOYS
+
+    # Names of the steps this builder generates; every other step on an existing
+    # *_deploy job is treated as a custom step to preserve.
+    GENERATED_STEP_NAMES = ['Setup', 'Install Vercel CLI', 'Pull Vercel Environment Information', 'Deploy Project to Vercel'].freeze
+    private_constant :GENERATED_STEP_NAMES
+
+    # JavaScript version files; when one is present the ci-actions setup reads the
+    # Node version from it, so a node-version carried over from a previous Setup
+    # step is dropped (mirrors LanguageJobBuilder#build_setup_step).
+    NODE_VERSION_FILES = %w[.node-version .nvmrc].freeze
+    private_constant :NODE_VERSION_FILES
+
+    DEPLOY_JOB_TIMEOUT_MINUTES = 60
+    private_constant :DEPLOY_JOB_TIMEOUT_MINUTES
+
+    def initialize(context:)
+      @options = context.options
+      @old_workflow = context.old_workflow
+      @new_workflow = context.new_workflow
+    end
+
+    def build
+      return if File.exist?('appspec.yml') # CodeDeploy owns the *_deploy jobs
+      return unless vercel?
+
+      puts('    Adding Vercel deploys...')
+
+      # Capture needs once, before any deploy job is added, so every deploy job
+      # depends on the build/test/lint jobs only - not on each other.
+      needs = @new_workflow.deploy_needs
+
+      DEPLOYS.each do |environment, config|
+        build_deploy_job(environment, config, needs)
+      end
+    end
+
+    private
+
+    # A repo deploys to Vercel when a vercel.json marker exists, or package.json
+    # declares a "vercel" or "next" dependency. Mirrors the Next.js detection
+    # RepositoryConfigurator uses to require the "Vercel" status check.
+    def vercel?
+      return true if File.exist?('vercel.json')
+
+      File.exist?('package.json') && File.read('package.json').match?(/"(?:vercel|next)"/)
+    end
+
+    def build_deploy_job(environment, config, needs)
+      job_id = :"#{environment}_deploy"
+      job_name = config[:name]
+      target = config[:target]
+      if_statement = build_if_statement(environment, needs)
+      old_job = @old_workflow.jobs[job_id]
+      builder = self
+
+      @new_workflow.do_job(job_id) do
+        copy_properties(old_job)
+        do_name(job_name)
+        do_runs_on(DEFAULT_UBUNTU_VERSION)
+        do_needs(needs)
+        do_if(if_statement)
+        do_timeout_minutes(DEPLOY_JOB_TIMEOUT_MINUTES) if timeout_minutes.nil?
+
+        if env.empty?
+          do_env(
+            {
+              VERCEL_ORG_ID: '${{secrets.VERCEL_ORG_ID}}',
+              VERCEL_PROJECT_ID: '${{secrets.VERCEL_PROJECT_ID}}'
+            }
+          )
+        end
+
+        builder.__send__(:build_setup_step, self, old_job)
+        builder.__send__(:build_install_step, self, old_job)
+        builder.__send__(:build_pull_step, self, old_job, target)
+        builder.__send__(:build_deploy_step, self, old_job, target)
+        builder.__send__(:append_custom_steps, self, old_job)
+      end
+    end
+
+    # The per-environment `if:` gating a single deploy job: run on its deploy
+    # trigger only if none of the build/test/lint jobs failed. Built from the
+    # captured needs list (not live @jobs.keys) so the three jobs never reference
+    # one another.
+    def build_if_statement(environment, needs)
+      base_condition = "always() && needs.variables.outputs.DEPLOY_ON_#{environment.to_s.upcase} == '1'"
+      job_conditions = needs.map { |job| "needs.#{job}.result != 'failure'" }
+
+      "${{#{([base_condition] + job_conditions).join(' && ')}}}"
+    end
+
+    def build_setup_step(job, old_job)
+      # A version file pins the Node version, so drop a carried-over node-version.
+      drop_node_version = NODE_VERSION_FILES.any? { |file| File.exist?(file) }
+
+      job.do_step('Setup') do
+        copy_properties(find_step(old_job&.steps, name))
+        do_uses("cloud-officer/ci-actions/setup@#{CI_ACTIONS_VERSION}")
+
+        with.delete(:'node-version') if drop_node_version
+
+        if with.empty?
+          do_with(
+            {
+              'ssh-key': '${{secrets.SSH_KEY}}',
+              'github-token': '${{secrets.GH_PAT}}',
+              'aws-access-key-id': '${{secrets.AWS_ACCESS_KEY_ID}}',
+              'aws-secret-access-key': '${{secrets.AWS_SECRET_ACCESS_KEY}}',
+              'aws-region': '${{secrets.AWS_DEFAULT_REGION}}'
+            }
+          )
+        end
+
+        with[:'github-token'] = '${{secrets.GH_PAT}}'
+      end
+    end
+
+    def build_install_step(job, old_job)
+      job.do_step('Install Vercel CLI') do
+        copy_properties(find_step(old_job&.steps, name))
+        do_run('npm install --global vercel@latest') if run.nil?
+      end
+    end
+
+    def build_pull_step(job, old_job, target)
+      job.do_step('Pull Vercel Environment Information') do
+        copy_properties(find_step(old_job&.steps, name))
+        do_run("vercel pull --yes --environment=#{target} --token=${{ secrets.VERCEL_TOKEN }}") if run.nil?
+      end
+    end
+
+    def build_deploy_step(job, old_job, target)
+      preview = target != 'production'
+
+      job.do_step('Deploy Project to Vercel') do
+        copy_properties(find_step(old_job&.steps, name))
+        do_id('deploy') if preview
+        next unless run.nil?
+
+        do_run(
+          if preview
+            'echo "url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})" >> "${GITHUB_OUTPUT}"'
+          else
+            'vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}'
+          end
+        )
+      end
+    end
+
+    # Re-append any non-generated steps (e.g. project-specific `vercel alias`
+    # steps) from the existing job so regeneration preserves them.
+    def append_custom_steps(job, old_job)
+      return if old_job.nil?
+
+      old_job.steps.each do |step|
+        job.steps << step unless GENERATED_STEP_NAMES.include?(step.name)
+      end
+    end
+  end
+end

--- a/spec/ghb/vercel_job_builder_spec.rb
+++ b/spec/ghb/vercel_job_builder_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+RSpec.describe(GHB::VercelJobBuilder) do
+  let(:options)      { instance_double(GHB::Options) }
+  let(:old_workflow) { GHB::Workflow.new('Old')      }
+  let(:new_workflow) { GHB::Workflow.new('Test')     }
+
+  # The build/test/lint jobs a real workflow has by the time deploy jobs are
+  # built; deploy needs/conditions are derived from these.
+  def populate_base_jobs
+    %i[variables actionlint markdownlint semgrep trivy yamllint licenses js_unit_tests].each do |id|
+      new_workflow.do_job(id) { do_name(id.to_s) }
+    end
+  end
+
+  def run_build(old: old_workflow)
+    described_class.new(
+      context: GHB::BuildContext.new(options: options, old_workflow: old, new_workflow: new_workflow)
+    ).build
+  end
+
+  before do
+    allow($stdout).to(receive(:puts))
+    # Nothing on disk unless a test opts in.
+    allow(File).to(receive(:exist?).and_return(false))
+  end
+
+  describe '#build' do
+    context 'when the repo is not a Vercel project' do
+      it 'returns early without adding jobs' do
+        populate_base_jobs
+
+        run_build
+
+        expect(new_workflow.jobs.keys).to(eq(%i[variables actionlint markdownlint semgrep trivy yamllint licenses js_unit_tests]))
+      end
+    end
+
+    context 'when appspec.yml exists' do
+      it 'leaves the *_deploy jobs to CodeDeploy and adds nothing' do
+        allow(File).to(receive(:exist?).with('appspec.yml').and_return(true))
+        allow(File).to(receive(:exist?).with('vercel.json').and_return(true))
+        populate_base_jobs
+
+        run_build
+
+        expect(new_workflow.jobs).not_to(include(:beta_deploy, :rc_deploy, :prod_deploy))
+      end
+    end
+
+    context 'when a vercel.json marker is present' do
+      before do
+        allow(File).to(receive(:exist?).with('vercel.json').and_return(true))
+        populate_base_jobs
+      end
+
+      it 'adds beta_deploy, rc_deploy and prod_deploy jobs' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        expect(new_workflow.jobs).to(have_key(:beta_deploy))
+        expect(new_workflow.jobs).to(have_key(:rc_deploy))
+        expect(new_workflow.jobs).to(have_key(:prod_deploy))
+      end
+
+      it 'names rc "RC Deploy" (matching the Vercel template, not CodeDeploy "Rc Deploy")' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        expect(new_workflow.jobs[:beta_deploy].name).to(eq('Beta Deploy'))
+        expect(new_workflow.jobs[:rc_deploy].name).to(eq('RC Deploy'))
+        expect(new_workflow.jobs[:prod_deploy].name).to(eq('Prod Deploy'))
+      end
+
+      it 'makes deploy jobs depend on the build/test/lint jobs, not on each other' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        expect(new_workflow.jobs[:rc_deploy].needs).to(eq(%w[variables actionlint markdownlint semgrep trivy yamllint licenses js_unit_tests]))
+        expect(new_workflow.jobs[:rc_deploy].needs).not_to(include('beta_deploy', 'prod_deploy'))
+      end
+
+      it 'gates each job on its own DEPLOY_ON_* flag and every prior job result' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        run_build
+
+        prod_if = new_workflow.jobs[:prod_deploy].if
+        expect(prod_if).to(include("needs.variables.outputs.DEPLOY_ON_PROD == '1'"))
+        expect(prod_if).to(include("needs.js_unit_tests.result != 'failure'"))
+        expect(prod_if).not_to(include('DEPLOY_ON_BETA'))
+        expect(prod_if).not_to(include('beta_deploy'))
+      end
+
+      it 'sets a 60-minute timeout and the Vercel org/project env' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        prod = new_workflow.jobs[:prod_deploy]
+        expect(prod.timeout_minutes).to(eq(60))
+        expect(prod.env[:VERCEL_ORG_ID]).to(eq('${{secrets.VERCEL_ORG_ID}}'))
+        expect(prod.env[:VERCEL_PROJECT_ID]).to(eq('${{secrets.VERCEL_PROJECT_ID}}'))
+      end
+
+      it 'generates the four Vercel CLI steps' do
+        run_build
+
+        expect(new_workflow.jobs[:prod_deploy].steps.map(&:name))
+          .to(eq(['Setup', 'Install Vercel CLI', 'Pull Vercel Environment Information', 'Deploy Project to Vercel']))
+      end
+
+      it 'deploys production with --prod and no output id' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        deploy = new_workflow.jobs[:prod_deploy].steps.last
+        expect(deploy.run).to(eq('vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}'))
+        expect(deploy.id).to(be_nil)
+        expect(new_workflow.jobs[:prod_deploy].steps[2].run).to(include('--environment=production'))
+      end
+
+      it 'deploys preview environments capturing the URL into the deploy step output' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        deploy = new_workflow.jobs[:rc_deploy].steps.last
+        expect(deploy.id).to(eq('deploy'))
+        expect(deploy.run).to(eq('echo "url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})" >> "${GITHUB_OUTPUT}"'))
+        expect(new_workflow.jobs[:rc_deploy].steps[2].run).to(include('--environment=preview'))
+      end
+
+      it 'drops a carried-over node-version from Setup when a version file pins it' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+        allow(File).to(receive(:exist?).with('.nvmrc').and_return(true))
+        old_workflow.do_job(:prod_deploy) do
+          do_step('Setup') do
+            do_uses('cloud-officer/ci-actions/setup@v2')
+            do_with({ 'ssh-key': '${{secrets.SSH_KEY}}', 'node-version': '${{env.NODE-VERSION}}' })
+          end
+        end
+
+        run_build
+
+        setup = new_workflow.jobs[:prod_deploy].steps.first
+        expect(setup.with).not_to(have_key(:'node-version'))
+        expect(setup.with[:'github-token']).to(eq('${{secrets.GH_PAT}}'))
+      end
+    end
+
+    context 'when package.json declares a Vercel/Next dependency' do
+      before { populate_base_jobs }
+
+      it 'detects "next"' do
+        allow(File).to(receive(:exist?).with('package.json').and_return(true))
+        allow(File).to(receive(:read).with('package.json').and_return('{ "dependencies": { "next": "^16.2.3" } }'))
+
+        run_build
+
+        expect(new_workflow.jobs).to(have_key(:prod_deploy))
+      end
+
+      it 'detects "vercel"' do
+        allow(File).to(receive(:exist?).with('package.json').and_return(true))
+        allow(File).to(receive(:read).with('package.json').and_return('{ "devDependencies": { "vercel": "^39" } }'))
+
+        run_build
+
+        expect(new_workflow.jobs).to(have_key(:prod_deploy))
+      end
+
+      it 'ignores look-alike packages such as "next-auth"' do
+        allow(File).to(receive(:exist?).with('package.json').and_return(true))
+        allow(File).to(receive(:read).with('package.json').and_return('{ "dependencies": { "next-auth": "^5" } }'))
+
+        run_build
+
+        expect(new_workflow.jobs).not_to(have_key(:prod_deploy))
+      end
+    end
+
+    context 'when an existing deploy job carries custom alias steps' do
+      before do
+        allow(File).to(receive(:exist?).with('vercel.json').and_return(true))
+        populate_base_jobs
+
+        old_workflow.do_job(:rc_deploy) do
+          do_name('RC Deploy')
+          do_step('Setup') { do_uses('cloud-officer/ci-actions/setup@v2') }
+          do_step('Pull Vercel Environment Information') do
+            do_run('vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }} --custom')
+          end
+          do_step('Deploy Project to Vercel') do
+            do_id('deploy')
+            do_run('echo "url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }})" >> "${GITHUB_OUTPUT}"')
+          end
+          do_step('Alias to rc.applaydu.app') do
+            do_run('vercel alias ${{ steps.deploy.outputs.url }} rc.applaydu.app --scope "ugroup-media" --token=${{ secrets.VERCEL_TOKEN }}')
+          end
+        end
+      end
+
+      it 'preserves the custom alias step, appended after the generated steps' do # rubocop:disable RSpec/MultipleExpectations
+        run_build
+
+        names = new_workflow.jobs[:rc_deploy].steps.map(&:name)
+        expect(names).to(eq(['Setup', 'Install Vercel CLI', 'Pull Vercel Environment Information', 'Deploy Project to Vercel', 'Alias to rc.applaydu.app']))
+        expect(new_workflow.jobs[:rc_deploy].steps.last.run).to(include('rc.applaydu.app'))
+      end
+
+      it 'keeps a customized run command on a regenerated step (copy_properties)' do
+        run_build
+
+        pull = new_workflow.jobs[:rc_deploy].steps[2]
+        expect(pull.run).to(eq('vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }} --custom'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`github-build` fully regenerates `build.yml` from its own builders, so any deploy job it does not itself produce was silently dropped on every run. For Vercel repos this meant the `beta_deploy` / `rc_deploy` / `prod_deploy` jobs disappeared whenever the generator ran — repeatedly breaking RC deploys and forcing manual restores.

This adds a `VercelJobBuilder`, the Vercel counterpart to `CodeDeployJobBuilder`: when a repo deploys to Vercel, the three per-environment deploy jobs are generated (and their project-specific custom steps preserved) instead of stripped.

**Key changes:**

- Add `lib/ghb/vercel_job_builder.rb`. Detection: a `vercel.json` marker is present, or `package.json` declares a `"vercel"` / `"next"` dependency. Generates `beta_deploy` / `rc_deploy` / `prod_deploy` driving the Vercel CLI (`prod` publishes with `--prod`; `beta`/`rc` deploy a preview build and capture the URL). Matches the existing hand-written Vercel template (`rc` is named "RC Deploy"), not the CodeDeploy variant.
- Preserve custom steps: any non-generated step on an existing `*_deploy` job (e.g. project-specific `vercel alias …` steps, whose domains the generator cannot know) is carried over so regeneration stops stripping them.
- CodeDeploy precedence: when `appspec.yml` exists, the `*_deploy` jobs are left to `CodeDeployJobBuilder` so the job names do not collide.
- Wire `VercelJobBuilder` into the pipeline in `lib/ghb/application.rb` (after CodeDeploy, before AWS) and require it.
- Add `spec/ghb/vercel_job_builder_spec.rb` (16 examples): detection paths, naming, per-environment `if:`/`needs`, prod vs preview deploy steps, env/timeout, node-version handling, and alias-step preservation.
- Document the trigger in the README Feature Triggers table and add `VercelJobBuilder` to `docs/architecture.md`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
