### PR TITLE
Update dependencies and tooling config, document LinterIgnoreRenderer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,11 +222,11 @@ jobs:
         github-token: "${{secrets.GH_PAT}}"
     - name: Bundler
       shell: bash
-      run: bundle install
+      run: echo "Already done by setup."
       env:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"
     - name: RSpec
       shell: bash
-      run: bundle exec rspec
+      run: bundle exec rspec --format documentation
       env:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"

--- a/.soup.json
+++ b/.soup.json
@@ -338,7 +338,7 @@
   "psych": {
     "language": "Ruby",
     "package": "psych",
-    "version": "5.3.1",
+    "version": "5.4.0",
     "license": "MIT",
     "description": "Psych is a YAML parser and emitter",
     "website": "https://github.com/ruby/psych",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -93,7 +93,7 @@ js:
     - .nvmrc
   setup_options:
     - name: node-version
-      value: 26.2.0
+      value: 26.3.0
     - name: node-always-auth
       value:
     - name: node-version-file
@@ -467,7 +467,7 @@ ruby:
       package_manager_update: bundle config set frozen false ; bundle update
       dependabot_ecosystem: bundler
   unit_test_framework_name: RSpec
-  unit_test_framework_default: bundle exec rspec
+  unit_test_framework_default: bundle exec rspec --format documentation
 # Directories to exclude from file scanning that are NOT package manager install dirs.
 # Combined with install_dirs values from dependency entries to form the complete exclusion list.
 # This combined set is also the single source of truth rendered into each linter

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,6 +249,18 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 - `find` (Ruby stdlib)
 
+### GHB::LinterIgnoreRenderer (Module)
+
+**Purpose:** Renders the canonical excluded-directory list (the same set `FileScanner` derives from `languages.yaml`) into each linter config's native ignore syntax, keeping every linter's ignore list aligned with a single source of truth. Each managed config carries a sentinel-delimited block (`ghb:excluded-dirs:start` / `ghb:excluded-dirs:end`) whose body is regenerated; configs without the sentinels are returned unchanged. Included as a mixin by `LinterJobBuilder`.
+
+**Location:** `lib/ghb/linter_ignore_renderer.rb`
+
+**Key Components:**
+
+- `FORMATS`: Maps each managed config file name (`.eslintrc.json`, `.flake8`, `.bandit`, `.yamllint.yml`, `.pmd.xml`) to its native-syntax body renderer
+- `manages?(config_name)`: Returns whether a given linter config has a managed excluded-dirs block
+- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns`, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries), or returns `content` unchanged when unmanaged or missing sentinels
+
 ### GHB::GitHubAPIClient
 
 **Purpose:** Centralized GitHub REST API client with shared headers, retry logic with linear backoff, and error handling.
@@ -285,12 +297,16 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 **Location:** `lib/ghb/linter_job_builder.rb`
 
-**Includes:** `GHB::FileScanner`
+**Includes:** `GHB::FileScanner`, `GHB::LinterIgnoreRenderer`
 
 **Key Components:**
 
 - `initialize(context:)`: Accepts a `GHB::BuildContext`
-- `build`: Loads linter config, parses `.gitmodules`, scans for matching files, and creates linter jobs with config file copying
+- `build`: Loads linter config, parses `.gitmodules`, scans for matching files, and creates linter jobs with config file copying. When copying a bundled linter config that `GHB::LinterIgnoreRenderer` manages, regenerates its excluded-dirs block from `excluded_dirs_from_config` so every linter's ignore list stays aligned with `languages.yaml`
+
+**Internal Dependencies:**
+
+- `GHB::LinterIgnoreRenderer`
 
 ### GHB::LicensesJobBuilder
 
@@ -586,7 +602,7 @@ All dependencies are managed via Bundler with versions locked in `Gemfile.lock`.
 3. For each linter, uses pure Ruby `find_files_matching` with regex pattern matching to search for files
 4. Excludes specified folders and submodules from search
 5. If a `content_match` string is configured, further filters matched files by checking file contents via `file_contains?`. When `content_match_pattern` is also set, only files whose path matches that sub-pattern require the content check; other files pass through unconditionally
-6. If matching files remain, enables the linter and resolves configuration files via a priority chain: cleans up deprecated config files that were renamed (tracked via `RENAMED_CONFIGS` constant, e.g., `.markdownlint.yml` → `.markdownlint-cli2.yaml`), preserves existing project-specific configs (when `preserve_config` is set and a non-symlink file exists), creates symlinks to a scripts submodule `linters/` directory, creates symlinks to a local `linters/` directory, or falls back to `atomic_copy_config` to safely copy bundled configs with optional transformation (e.g., uncommenting Rails rules in `.rubocop.yml`)
+6. If matching files remain, enables the linter and resolves configuration files via a priority chain: cleans up deprecated config files that were renamed (tracked via `RENAMED_CONFIGS` constant, e.g., `.markdownlint.yml` → `.markdownlint-cli2.yaml`), preserves existing project-specific configs (when `preserve_config` is set and a non-symlink file exists), creates symlinks to a scripts submodule `linters/` directory, creates symlinks to a local `linters/` directory, or falls back to `atomic_copy_config` to safely copy bundled configs with optional transformation (e.g., regenerating the excluded-dirs block via `GHB::LinterIgnoreRenderer` for managed configs, or uncommenting Rails rules in `.rubocop.yml`)
 7. Creates workflow job with appropriate steps for each enabled linter
 
 **Complexity:** O(n * m) where n = number of linters, m = files in repository

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -30,7 +30,7 @@
 | Ruby | parallel | 2.1.0 | MIT | Run any kind of code in parallel processes | <https://github.com/grosser/parallel> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | parser | 3.3.11.1 | MIT | A Ruby parser written in pure Ruby. | <https://github.com/whitequark/parser> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | prism | 1.9.0 | MIT | Prism Ruby parser | <https://github.com/ruby/prism> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | psych | 5.3.1 | MIT | Psych is a YAML parser and emitter | <https://github.com/ruby/psych> | 2026-05-22 | Low | Yaml parser | Ruby standard library gem maintained by the Ruby core team |
+| Ruby | psych | 5.4.0 | MIT | Psych is a YAML parser and emitter | <https://github.com/ruby/psych> | 2026-05-22 | Low | Yaml parser | Ruby standard library gem maintained by the Ruby core team |
 | Ruby | public_suffix | 7.0.5 | MIT | PublicSuffix can parse and decompose a domain name into top level domain, domain and subdomains. | <https://simonecarletti.com/code/publicsuffix-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | racc | 1.8.1 | Ruby | Racc is an LALR(1) parser generator. | <https://github.com/ruby/racc> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rainbow | 3.1.1 | MIT | Colorize printed text on ANSI terminals | <https://github.com/sickill/rainbow> | 2026-05-22 | Low | Dependency | Dependency |

--- a/spec/fixtures/workflow_generation/build.yml
+++ b/spec/fixtures/workflow_generation/build.yml
@@ -131,6 +131,6 @@ jobs:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"
     - name: RSpec
       shell: bash
-      run: bundle exec rspec
+      run: bundle exec rspec --format documentation
       env:
         GITHUB_TOKEN: "${{secrets.GH_PAT}}"


### PR DESCRIPTION
## Summary

Routine dependency and tooling-config refresh. Bumps the Node and `psych`
versions, switches RSpec to documentation-formatted output across the generated
workflow and its source config, skips the now-redundant `bundle install` step
(already handled by setup), and brings `docs/architecture.md` up to date with
the `GHB::LinterIgnoreRenderer` module introduced in #429.

**Key changes:**

- Bump Node version `26.2.0` → `26.3.0` in `config/languages.yaml`
- Bump `psych` `5.3.1` → `5.4.0` in `Gemfile.lock`
- Use `bundle exec rspec --format documentation` as the Ruby unit-test default,
  reflected in `config/languages.yaml`, the generated `.github/workflows/build.yml`,
  and the `spec/fixtures/workflow_generation/build.yml` fixture
- Replace the redundant `bundle install` Bundler step with an echo note
  ("Already done by setup.") in the generated `build.yml`
- Document `GHB::LinterIgnoreRenderer` and its use by `LinterJobBuilder` in
  `docs/architecture.md`
- Update SOUP files (`.soup.json`, `docs/soup.md`) for the dependency change

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Config/docs change; covered by the existing workflow-generation fixture spec
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [x] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified