### PR TITLE
Exclude *.workflow.js (Workflow DSL scripts) from ESLint and Semgrep

### DIFF
--- a/config/linters.yaml
+++ b/config/linters.yaml
@@ -66,7 +66,12 @@ eslint:
   uses: cloud-officer/ci-actions/linters/eslint
   config: ".eslintrc.json"
   path: "."
-  pattern: ".*\\.(js|mjs|cjs)$"
+  # Excludes *.workflow.js (Workflow DSL scripts): they combine `export const meta`
+  # with a top-level `return`, which no single ESLint parser mode can parse. The
+  # negative lookahead means a repo whose only JS is workflow scripts won't enable
+  # ESLint at all (and its .eslintrc.json is removed). Mixed repos still run ESLint
+  # but skip these files via the **/*.workflow.js entry in .eslintrc.json.
+  pattern: "^(?!.*\\.workflow\\.js$).*\\.(js|mjs|cjs)$"
 flake8:
   short_name: Flake8
   long_name: Python Flake8 Linter
@@ -155,7 +160,10 @@ semgrep:
   config: ".semgrepignore"
   preserve_config: true
   path: "."
-  pattern: ".*\\.(py|js|mjs|cjs|jsx|ts|tsx|go|rb|java|kt|php|c|cpp|cs|rs|swift|scala)$"
+  # Excludes *.workflow.js (Workflow DSL scripts) so a repo whose only scannable
+  # files are workflow scripts won't enable Semgrep (parity with ESLint). Mixed
+  # repos still run Semgrep but skip these files via .semgrepignore.
+  pattern: "^(?!.*\\.workflow\\.js$).*\\.(py|js|mjs|cjs|jsx|ts|tsx|go|rb|java|kt|php|c|cpp|cs|rs|swift|scala)$"
 shellcheck:
   short_name: ShellCheck
   long_name: Shell Scripts Linter

--- a/config/linters/.eslintrc.json
+++ b/config/linters/.eslintrc.json
@@ -4,7 +4,7 @@
     "es2021": true
   },
   // ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
-  "ignorePatterns": ["**/.build/**", "**/.bundle/**", "**/.git/**", "**/.gradle/**", "**/.hg/**", "**/.m2/**", "**/.npm/**", "**/.pnpm/**", "**/.pytest_cache/**", "**/.svn/**", "**/.venv/**", "**/.yarn/**", "**/__pycache__/**", "**/build/**", "**/Carthage/**", "**/coverage/**", "**/DerivedData/**", "**/dist/**", "**/env/**", "**/Libraries/**", "**/node_modules/**", "**/Pods/**", "**/target/**", "**/vendor/**", "**/venv/**"],
+  "ignorePatterns": ["**/.build/**", "**/.bundle/**", "**/.git/**", "**/.gradle/**", "**/.hg/**", "**/.m2/**", "**/.npm/**", "**/.pnpm/**", "**/.pytest_cache/**", "**/.svn/**", "**/.venv/**", "**/.yarn/**", "**/__pycache__/**", "**/build/**", "**/Carthage/**", "**/coverage/**", "**/DerivedData/**", "**/dist/**", "**/env/**", "**/Libraries/**", "**/node_modules/**", "**/Pods/**", "**/target/**", "**/vendor/**", "**/venv/**", "**/*.workflow.js"],
   // ghb:excluded-dirs:end
   "extends": ["eslint:recommended"],
   "parserOptions": {

--- a/config/linters/.semgrepignore
+++ b/config/linters/.semgrepignore
@@ -24,6 +24,10 @@ target/
 **/*.spec.js
 **/*.spec.ts
 
+# Workflow DSL scripts (Claude Code): not standard modules, validated by the
+# Workflow runtime rather than static analysis
+**/*.workflow.js
+
 # Test directories
 **/test/
 **/tests/

--- a/lib/ghb/linter_ignore_renderer.rb
+++ b/lib/ghb/linter_ignore_renderer.rb
@@ -22,6 +22,17 @@ module GHB
     SENTINEL_PATTERN = /(.*#{Regexp.escape(SENTINEL_START)}.*\n)(?:.*\n)*?(.*#{Regexp.escape(SENTINEL_END)}.*)/
     private_constant :SENTINEL_PATTERN
 
+    # ESLint-only static ignores layered on top of the canonical excluded dirs.
+    # Workflow DSL scripts (*.workflow.js) legitimately combine a top-level
+    # `export const meta` with a top-level `return` (the Workflow runtime extracts
+    # the meta export and wraps the body in an async function), which no single
+    # ESLint parser mode can parse. They are validated by the Workflow runtime,
+    # not ESLint, so they are always ignored. This is a file glob (not a
+    # directory) and specific to ESLint, hence kept here rather than in the
+    # shared excluded_dirs list.
+    ESLINT_EXTRA_IGNORES = ['**/*.workflow.js'].freeze
+    private_constant :ESLINT_EXTRA_IGNORES
+
     # config file name (as symbol) => body renderer for its native syntax
     FORMATS = {
       '.eslintrc.json': :body_eslint,
@@ -66,6 +77,7 @@ module GHB
 
     def body_eslint(dirs)
       patterns = dirs.map { |dir| %("**/#{dir}/**") }
+      patterns.concat(ESLINT_EXTRA_IGNORES.map { |glob| %("#{glob}") })
       %(  "ignorePatterns": [#{patterns.join(', ')}],)
     end
 

--- a/spec/ghb/linter_ignore_renderer_spec.rb
+++ b/spec/ghb/linter_ignore_renderer_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe(GHB::LinterIgnoreRenderer) do
   let(:dirs) { %w[vendor node_modules Build node_modules coverage .git] }
 
   describe '#render_excluded_dirs' do
-    it 'renders the eslint ignorePatterns as sorted glob patterns' do
+    it 'renders the eslint ignorePatterns as sorted glob patterns, then the eslint-only file globs' do
       content = "{\n  // ghb:excluded-dirs:start\n  \"ignorePatterns\": [\"**/old/**\"],\n  // ghb:excluded-dirs:end\n}\n"
 
       result = renderer.render_excluded_dirs('.eslintrc.json', content, dirs)
 
-      expect(result).to(include('"ignorePatterns": ["**/.git/**", "**/Build/**", "**/coverage/**", "**/node_modules/**", "**/vendor/**"],'))
+      expect(result).to(include('"ignorePatterns": ["**/.git/**", "**/Build/**", "**/coverage/**", "**/node_modules/**", "**/vendor/**", "**/*.workflow.js"],'))
     end
 
     it 'renders the flake8 extend-exclude as a sorted comma list' do

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -745,4 +745,24 @@ RSpec.describe(GHB::LinterJobBuilder) do
       end
     end
   end
+
+  # Workflow DSL scripts (*.workflow.js) must not trigger the JS-based linters:
+  # they are validated by the Workflow runtime, not eslint/semgrep.
+  describe 'workflow DSL detection patterns' do
+    let(:linters) { Psych.safe_load(File.read('config/linters.yaml')) }
+
+    it 'excludes *.workflow.js from eslint detection but matches regular JS' do
+      pattern = Regexp.new(linters['eslint']['pattern'])
+      cases = [['./commands/code-review-deep.workflow.js', false], ['./src/app.js', true], ['./src/index.mjs', true]]
+
+      cases.each { |path, expected| expect(pattern.match?(path)).to(be(expected)) }
+    end
+
+    it 'excludes *.workflow.js from semgrep detection but matches other source files' do
+      pattern = Regexp.new(linters['semgrep']['pattern'])
+      cases = [['./commands/code-review-deep.workflow.js', false], ['./src/app.js', true], ['./lib/foo.py', true], ['./main.go', true]]
+
+      cases.each { |path, expected| expect(pattern.match?(path)).to(be(expected)) }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Workflow DSL scripts (`*.workflow.js`, e.g. Claude Code `commands/*.workflow.js`) combine a top-level `export const meta` with a top-level `return` — a valid contract for the Workflow runtime (it extracts the meta export and wraps the body in an async function), but unparseable by ESLint (no single parser mode allows `export` + top-level `return`). They are validated by the Workflow runtime, not by static analysis, so they should not be linted. This makes that exclusion the default for all repos.

**Key changes:**

- **Detection (`config/linters.yaml`):** ESLint and Semgrep detection patterns now use a negative lookahead `^(?!.*\.workflow\.js$)...`, so a repo whose only scannable files are workflow scripts no longer enables that linter (and ESLint's `.eslintrc.json` is removed by `delete_linter_config`).
- **Mixed repos still run the linters but skip workflow files:** `**/*.workflow.js` is appended to `.eslintrc.json` `ignorePatterns` (added in `body_eslint` in `lib/ghb/linter_ignore_renderer.rb`, since that line is regenerated from the excluded-dirs source) and to the default `config/linters/.semgrepignore`.
- **Tests:** updated the renderer spec for the new ignore entry and added `workflow DSL detection patterns` specs covering both linters' patterns. Full suite green (391 examples), `linters` clean.

Note: Semgrep is `preserve_config: true`, so repos that already committed a `.semgrepignore` will not auto-pick-up the new entry — only new/missing ones get the updated default.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified