### PR TITLE
Don't warn on version-file patch refinements (e.g. .php-version 8.5 vs 8.5.6)

### DIFF
--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -314,7 +314,7 @@ module GHB
           if option_value
             file_version = File.read(version_file).strip
 
-            if file_version != option_value.to_s
+            if version_file_mismatch?(file_version, option_value.to_s)
               puts("\e[31m\n#{'*' * 80}")
               puts("WARNING: Value mismatch for #{option[:name].upcase}")
               puts("Version file (#{version_file}): #{file_version}")
@@ -360,6 +360,18 @@ module GHB
         @new_workflow.env[option[:name].upcase.to_sym] = value unless @new_workflow.env[option[:name].upcase.to_sym]
         setup_options[option[:name]] = "${{env.#{option[:name].upcase}}}"
       end
+    end
+
+    # A version file may intentionally pin fewer segments than the recommended
+    # value: e.g. .php-version pins "8.5" and setup-php/phpenv resolve the latest
+    # patch at install time. A recommendation that only adds a more specific
+    # patch within the same prefix is not a real mismatch, so it must not
+    # trigger a version-mismatch warning.
+    def version_file_mismatch?(file_version, recommended)
+      return false if file_version == recommended
+      return false if recommended.start_with?("#{file_version}.")
+
+      true
     end
   end
 end

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -641,6 +641,24 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     end
   end
 
+  describe '#version_file_mismatch?' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    it 'treats a recommendation that only adds a more specific patch as a match (.php-version 8.5 vs 8.5.6)' do
+      expect(builder.__send__(:version_file_mismatch?, '8.5', '8.5.6')).to(be(false))
+    end
+
+    it 'treats an identical version as a match' do
+      expect(builder.__send__(:version_file_mismatch?, '3.13.13', '3.13.13')).to(be(false))
+    end
+
+    it 'flags a real minor-version difference as a mismatch (.python-version 3.13.13 vs 3.14.5)' do
+      expect(builder.__send__(:version_file_mismatch?, '3.13.13', '3.14.5')).to(be(true))
+    end
+
+    it 'does not treat a numerically adjacent prefix as a match (8.5 vs 8.50.0)' do
+      expect(builder.__send__(:version_file_mismatch?, '8.5', '8.50.0')).to(be(true))
+    end
+  end
+
   private
 
   def stub_config_file_reads(languages_yaml)


### PR DESCRIPTION
## Summary

The version-file vs recommended-value comparison in `add_setup_options` used a raw string equality, so a `.php-version` pinned at major.minor (e.g. `8.5`) was flagged as a mismatch against the recommended patch (e.g. `8.5.6`). That pin is intentional — setup-php/phpenv resolve the latest patch at install time — so the warning is noise.

**Key changes:**

- `lib/ghb/language_job_builder.rb`: add `version_file_mismatch?`, used by `add_setup_options` instead of raw `!=`. A recommendation that only adds a more specific patch within the same prefix (`8.5` vs `8.5.6`) is a match; real differences (`.python-version` `3.13.13` vs `3.14.5`) still warn.
- `spec/ghb/language_job_builder_spec.rb`: add a `#version_file_mismatch?` spec (prefix-match, identical, real-mismatch, adjacent-prefix).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
