### PR TITLE
Bump Go to 1.26.4 and document ESLINT_EXTRA_IGNORES

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -57,7 +57,7 @@ go:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.26.3
+      value: 1.26.4
     - name: go-version-file
       value:
     - name: go-check-latest
@@ -301,7 +301,7 @@ proto:
     - .go-version
   setup_options:
     - name: go-version
-      value: 1.26.3
+      value: 1.26.4
     - name: go-version-file
       value:
     - name: go-check-latest

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,8 +258,9 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 **Key Components:**
 
 - `FORMATS`: Maps each managed config file name (`.eslintrc.json`, `.flake8`, `.bandit`, `.yamllint.yml`, `.pmd.xml`) to its native-syntax body renderer
+- `ESLINT_EXTRA_IGNORES`: ESLint-only static globs (`**/*.workflow.js`) layered on top of the canonical excluded dirs. Workflow DSL scripts combine a top-level `export const meta` with a top-level `return` that no single ESLint parser mode can parse; they are validated by the Workflow runtime, not ESLint, so they are always ignored
 - `manages?(config_name)`: Returns whether a given linter config has a managed excluded-dirs block
-- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns`, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries), or returns `content` unchanged when unmanaged or missing sentinels
+- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns` — including the `ESLINT_EXTRA_IGNORES` globs, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries), or returns `content` unchanged when unmanaged or missing sentinels
 
 ### GHB::GitHubAPIClient
 


### PR DESCRIPTION
## Summary

Routine dependency refresh bumping the managed Go toolchain version from 1.26.3 to 1.26.4 across the language definitions, along with an architecture documentation update describing the \`ESLINT_EXTRA_IGNORES\` mechanism for the linter config renderer.

**Key changes:**

- Bump \`go-version\` from \`1.26.3\` to \`1.26.4\` for the \`go\` and \`proto\` language definitions in \`config/languages.yaml\`
- Document \`ESLINT_EXTRA_IGNORES\` in \`docs/architecture.md\`, explaining the ESLint-only static globs (\`**/*.workflow.js\`) layered on top of the canonical excluded dirs and why workflow DSL scripts are always ignored
- Clarify \`render_excluded_dirs\` documentation to note the \`ESLINT_EXTRA_IGNORES\` globs are included in the ESLint \`ignorePatterns\` output

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration version bump and documentation-only changes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [x] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified