### PR TITLE
Render excluded-dirs blocks for Semgrep, cfn-lint, and SwiftLint

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,6 +1,31 @@
 # Dependency directories
-vendor/
+# ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+.build/
+.bundle/
+.git/
+.gradle/
+.hg/
+.m2/
+.npm/
+.pnpm/
+.pytest_cache/
+.svn/
+.venv/
+.yarn/
+__pycache__/
+build/
+Carthage/
+coverage/
+DerivedData/
+dist/
+env/
+Libraries/
 node_modules/
+Pods/
+target/
+vendor/
+venv/
+# ghb:excluded-dirs:end
 
 # Test files - Go
 *_test.go
@@ -14,6 +39,10 @@ node_modules/
 **/*.test.ts
 **/*.spec.js
 **/*.spec.ts
+
+# Workflow DSL scripts (Claude Code): not standard modules, validated by the
+# Workflow runtime rather than static analysis
+**/*.workflow.js
 
 # Test directories
 **/test/

--- a/.soup.json
+++ b/.soup.json
@@ -206,7 +206,7 @@
   "json": {
     "language": "Ruby",
     "package": "json",
-    "version": "2.19.7",
+    "version": "2.19.8",
     "license": "Ruby",
     "description": "A JSON implementation as a JRuby extension.",
     "website": "https://github.com/ruby/json",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.19.7)
+    json (2.19.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/config/linters.yaml
+++ b/config/linters.yaml
@@ -24,7 +24,7 @@
 #   path             (string, required) - Root directory to search for files matching `pattern`
 #   pattern          (string, required) - Regex pattern to match source files (e.g., ".*\\.(py)$")
 #   preserve_config  (bool, optional)   - If true, keeps the project's existing config file instead
-#                                         of overwriting it. Used by Semgrep for custom .semgrepignore
+#                                         of overwriting it. Used by Trivy for a custom .trivyignore
 #   content_match    (string, optional) - If set, files matching `pattern` are further filtered:
 #                                         only files containing this literal string are kept.
 #                                         Useful when file extensions alone can't identify the language
@@ -158,7 +158,6 @@ semgrep:
   condition: "github.event_name == 'pull_request'"
   uses: cloud-officer/ci-actions/linters/semgrep
   config: ".semgrepignore"
-  preserve_config: true
   path: "."
   # Excludes *.workflow.js (Workflow DSL scripts) so a repo whose only scannable
   # files are workflow scripts won't enable Semgrep (parity with ESLint). Mixed
@@ -177,7 +176,6 @@ swiftlint:
   long_name: Swift Linter
   uses: cloud-officer/ci-actions/linters/swiftlint
   config: ".swiftlint.yml"
-  preserve_config: true
   path: "."
   pattern: ".*\\.(swift)$"
 trivy:

--- a/config/linters/.cfnlintrc
+++ b/config/linters/.cfnlintrc
@@ -3,14 +3,30 @@ templates:
 ignore_templates:
   - .github/**
   - docs/**
-  - node_modules/**
-  - vendor/**
+  # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
   - .build/**
-  - Pods/**
-  - Carthage/**
-  - DerivedData/**
-  - venv/**
+  - .bundle/**
+  - .git/**
+  - .gradle/**
+  - .hg/**
+  - .m2/**
+  - .npm/**
+  - .pnpm/**
+  - .pytest_cache/**
+  - .svn/**
   - .venv/**
-  - dist/**
+  - .yarn/**
+  - __pycache__/**
   - build/**
+  - Carthage/**
+  - coverage/**
+  - DerivedData/**
+  - dist/**
+  - env/**
+  - Libraries/**
+  - node_modules/**
+  - Pods/**
   - target/**
+  - vendor/**
+  - venv/**
+  # ghb:excluded-dirs:end

--- a/config/linters/.semgrepignore
+++ b/config/linters/.semgrepignore
@@ -1,15 +1,31 @@
 # Dependency directories
-vendor/
-node_modules/
+# ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
 .build/
-Pods/
-Carthage/
-DerivedData/
-venv/
+.bundle/
+.git/
+.gradle/
+.hg/
+.m2/
+.npm/
+.pnpm/
+.pytest_cache/
+.svn/
 .venv/
-dist/
+.yarn/
+__pycache__/
 build/
+Carthage/
+coverage/
+DerivedData/
+dist/
+env/
+Libraries/
+node_modules/
+Pods/
 target/
+vendor/
+venv/
+# ghb:excluded-dirs:end
 
 # Test files - Go
 *_test.go

--- a/config/linters/.swiftlint.yml
+++ b/config/linters/.swiftlint.yml
@@ -1,18 +1,43 @@
 excluded:
+  # Swift-specific paths not covered by the shared excluded-dirs list
   - .tuist-bin
-  - Carthage
   - Derived
   - Frameworks
   - Package.swift
-  - Pods
   - Project.swift
   - SourcePackages
   - Tests
-  - .build
   - Tuist/.build
   - Tuist/Cache
   - Tuist/Dependencies
   - fastlane
+  # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+  - .build
+  - .bundle
+  - .git
+  - .gradle
+  - .hg
+  - .m2
+  - .npm
+  - .pnpm
+  - .pytest_cache
+  - .svn
+  - .venv
+  - .yarn
+  - __pycache__
+  - build
+  - Carthage
+  - coverage
+  - DerivedData
+  - dist
+  - env
+  - Libraries
+  - node_modules
+  - Pods
+  - target
+  - vendor
+  - venv
+  # ghb:excluded-dirs:end
 disabled_rules:
   - comment_spacing
   - empty_enum_arguments

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,10 +257,10 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 **Key Components:**
 
-- `FORMATS`: Maps each managed config file name (`.eslintrc.json`, `.flake8`, `.bandit`, `.yamllint.yml`, `.pmd.xml`) to its native-syntax body renderer
+- `FORMATS`: Maps each managed config file name (`.eslintrc.json`, `.flake8`, `.bandit`, `.yamllint.yml`, `.pmd.xml`, `.semgrepignore`, `.cfnlintrc`, `.swiftlint.yml`) to its native-syntax body renderer
 - `ESLINT_EXTRA_IGNORES`: ESLint-only static globs (`**/*.workflow.js`) layered on top of the canonical excluded dirs. Workflow DSL scripts combine a top-level `export const meta` with a top-level `return` that no single ESLint parser mode can parse; they are validated by the Workflow runtime, not ESLint, so they are always ignored
 - `manages?(config_name)`: Returns whether a given linter config has a managed excluded-dirs block
-- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns` — including the `ESLINT_EXTRA_IGNORES` globs, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries), or returns `content` unchanged when unmanaged or missing sentinels
+- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns` — including the `ESLINT_EXTRA_IGNORES` globs, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries, gitignore-style lines for `.semgrepignore`, cfn-lint `ignore_templates` globs, SwiftLint `excluded` list items), or returns `content` unchanged when unmanaged or missing sentinels
 
 ### GHB::GitHubAPIClient
 

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -19,7 +19,7 @@
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | High | HTTP client for GitHub REST API communication | Industry-standard Ruby HTTP client with active maintenance and security updates |
 | Ruby | i18n | 1.14.8 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | json | 2.19.7 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Dependency | Dependency |
+| Ruby | json | 2.19.8 | Ruby | A JSON implementation as a JRuby extension. | <https://github.com/ruby/json> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | language_server-protocol | 3.17.0.5 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | logger | 1.7.0 | Ruby | Provides a simple logging utility for outputting messages. | <https://github.com/ruby/logger> | 2026-05-22 | Low | Dependency | Dependency |

--- a/lib/ghb/linter_ignore_renderer.rb
+++ b/lib/ghb/linter_ignore_renderer.rb
@@ -39,7 +39,10 @@ module GHB
       '.flake8': :body_flake8,
       '.bandit': :body_bandit,
       '.yamllint.yml': :body_yamllint,
-      '.pmd.xml': :body_pmd
+      '.pmd.xml': :body_pmd,
+      '.semgrepignore': :body_semgrepignore,
+      '.cfnlintrc': :body_cfnlint,
+      '.swiftlint.yml': :body_swiftlint
     }.freeze
     public_constant :FORMATS
 
@@ -96,6 +99,27 @@ module GHB
 
     def body_pmd(dirs)
       lines = dirs.map { |dir| "  <exclude-pattern>.*/#{dir}/.*</exclude-pattern>" }
+      lines.join("\n")
+    end
+
+    # Semgrep reads .semgrepignore as gitignore-style patterns, one per line.
+    def body_semgrepignore(dirs)
+      lines = dirs.map { |dir| "#{dir}/" }
+      lines.join("\n")
+    end
+
+    # cfn-lint's ignore_templates is a YAML list of globs; match the directory
+    # anywhere in the tree with a trailing `/**`.
+    def body_cfnlint(dirs)
+      lines = dirs.map { |dir| "  - #{dir}/**" }
+      lines.join("\n")
+    end
+
+    # SwiftLint's excluded: is a YAML list of paths. The managed block carries the
+    # shared dirs; Swift-specific extras (e.g. SourcePackages, Tuist/.build) live
+    # outside the sentinels in the shipped template.
+    def body_swiftlint(dirs)
+      lines = dirs.map { |dir| "  - #{dir}" }
       lines.join("\n")
     end
   end

--- a/spec/ghb/linter_ignore_renderer_spec.rb
+++ b/spec/ghb/linter_ignore_renderer_spec.rb
@@ -53,6 +53,30 @@ RSpec.describe(GHB::LinterIgnoreRenderer) do
       expect(result).to(include("  <exclude-pattern>.*/.git/.*</exclude-pattern>\n  <exclude-pattern>.*/Build/.*</exclude-pattern>"))
     end
 
+    it 'renders the semgrepignore block as gitignore-style, slash-suffixed lines' do
+      content = "# deps\n# ghb:excluded-dirs:start\nold/\n# ghb:excluded-dirs:end\n"
+
+      result = renderer.render_excluded_dirs('.semgrepignore', content, dirs)
+
+      expect(result).to(include(".git/\nBuild/\ncoverage/\nnode_modules/\nvendor/"))
+    end
+
+    it 'renders the cfn-lint ignore_templates block as indented glob list items' do
+      content = "ignore_templates:\n  # ghb:excluded-dirs:start\n  - old/**\n  # ghb:excluded-dirs:end\n"
+
+      result = renderer.render_excluded_dirs('.cfnlintrc', content, dirs)
+
+      expect(result).to(include("  - .git/**\n  - Build/**\n  - coverage/**\n  - node_modules/**\n  - vendor/**"))
+    end
+
+    it 'renders the swiftlint excluded block as indented list items, preserving Swift-specific extras' do
+      content = "excluded:\n  - SourcePackages\n  # ghb:excluded-dirs:start\n  - old\n  # ghb:excluded-dirs:end\n"
+
+      result = renderer.render_excluded_dirs('.swiftlint.yml', content, dirs)
+
+      expect(result).to(include("  - SourcePackages\n  # ghb:excluded-dirs:start\n  - .git\n  - Build\n  - coverage\n  - node_modules\n  - vendor"))
+    end
+
     it 'is idempotent' do
       content = "[flake8]\n# ghb:excluded-dirs:start\nextend-exclude = old\n# ghb:excluded-dirs:end\n"
 

--- a/spec/ghb/linter_job_builder_spec.rb
+++ b/spec/ghb/linter_job_builder_spec.rb
@@ -251,21 +251,21 @@ RSpec.describe(GHB::LinterJobBuilder) do
           )
         )
 
-        # Only match semgrep pattern
+        # Only match trivy pattern. Match `(tf)` -- unique to trivy's pattern.
         allow(builder).to(receive(:find_files_matching).and_return([]))
-        allow(builder).to(receive(:find_files_matching).with(anything, satisfy { |p| p.source.include?('swift') && p.source.include?('py') }, anything).and_return(['app.py']))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('(tf)')), anything).and_return(['main.tf']))
 
-        # Semgrep config is .semgrepignore with preserve_config: true
+        # Trivy config is .trivyignore with preserve_config: true
         # No script_path (no .gitmodules), so script_path is nil
-        # File.exist?("#{nil}/linters/.semgrepignore") should be false
-        allow(File).to(receive(:exist?).with('/linters/.semgrepignore').and_return(false))
+        # File.exist?("#{nil}/linters/.trivyignore") should be false
+        allow(File).to(receive(:exist?).with('/linters/.trivyignore').and_return(false))
         # The config file exists and is NOT a symlink -> preserve
-        allow(File).to(receive(:exist?).with('.semgrepignore').and_return(true))
-        allow(File).to(receive(:symlink?).with('.semgrepignore').and_return(false))
+        allow(File).to(receive(:exist?).with('.trivyignore').and_return(true))
+        allow(File).to(receive(:symlink?).with('.trivyignore').and_return(false))
 
         builder.build
 
-        expect(new_workflow.jobs).to(have_key(:semgrep))
+        expect(new_workflow.jobs).to(have_key(:trivy))
         # Config should be preserved - no write or mv should happen for the config
         expect(File).not_to(have_received(:write))
       end
@@ -463,9 +463,11 @@ RSpec.describe(GHB::LinterJobBuilder) do
           )
         )
 
-        # Enable only eslint (its pattern uniquely contains 'mjs')
+        # Enable only eslint. Match its full alternation group `(js|mjs|cjs)`,
+        # which is unique to eslint -- Semgrep's catch-all pattern contains the
+        # bare tokens (js, mjs, cjs) but never that exact grouping.
         allow(builder).to(receive(:find_files_matching).and_return([]))
-        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('mjs')), anything).and_return(['app.js']))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('(js|mjs|cjs)')), anything).and_return(['app.js']))
 
         # No script_path / no preserve_config -> falls through to atomic_copy_config,
         # which reads the real template (with sentinels) and writes the rendered copy.
@@ -591,12 +593,12 @@ RSpec.describe(GHB::LinterJobBuilder) do
         # No files match any linter pattern
         allow(builder).to(receive(:find_files_matching).and_return([]))
 
-        # Semgrep has preserve_config: true; its config exists and is NOT a symlink
-        allow(File).to(receive(:exist?).with('.semgrepignore').and_return(true))
+        # Trivy has preserve_config: true; its config exists and is NOT a symlink
+        allow(File).to(receive(:exist?).with('.trivyignore').and_return(true))
 
         builder.build
 
-        expect(File).not_to(have_received(:delete).with('.semgrepignore'))
+        expect(File).not_to(have_received(:delete).with('.trivyignore'))
       end
     end
 
@@ -635,21 +637,21 @@ RSpec.describe(GHB::LinterJobBuilder) do
           )
         )
 
-        # Only match semgrep pattern
+        # Only match trivy pattern. Match `(tf)` -- unique to trivy's pattern.
         allow(builder).to(receive(:find_files_matching).and_return([]))
-        allow(builder).to(receive(:find_files_matching).with(anything, satisfy { |p| p.source.include?('swift') && p.source.include?('py') }, anything).and_return(['app.py']))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('(tf)')), anything).and_return(['main.tf']))
 
         # script_path has the config
-        allow(File).to(receive(:exist?).with('scripts-repo/linters/.semgrepignore').and_return(true))
+        allow(File).to(receive(:exist?).with('scripts-repo/linters/.trivyignore').and_return(true))
         # Project has its own non-symlink config
-        allow(File).to(receive(:exist?).with('.semgrepignore').and_return(true))
-        allow(File).to(receive(:symlink?).with('.semgrepignore').and_return(false))
+        allow(File).to(receive(:exist?).with('.trivyignore').and_return(true))
+        allow(File).to(receive(:symlink?).with('.trivyignore').and_return(false))
         allow(FileUtils).to(receive(:ln_s))
 
         builder.build
 
-        expect(new_workflow.jobs).to(have_key(:semgrep))
-        expect(FileUtils).not_to(have_received(:ln_s).with('scripts-repo/linters/.semgrepignore', '.semgrepignore', force: true))
+        expect(new_workflow.jobs).to(have_key(:trivy))
+        expect(FileUtils).not_to(have_received(:ln_s).with('scripts-repo/linters/.trivyignore', '.trivyignore', force: true))
       end
     end
 
@@ -688,9 +690,10 @@ RSpec.describe(GHB::LinterJobBuilder) do
           )
         )
 
-        # Only match golangci pattern (go files)
+        # Only match golangci pattern. Match `(go)` -- unique to golangci's
+        # `.*\.(go)$`; Semgrep's catch-all has the bare token `go` but never `(go)`.
         allow(builder).to(receive(:find_files_matching).and_return([]))
-        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('go')), anything).and_return(['main.go']))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('(go)')), anything).and_return(['main.go']))
 
         # script_path will be 'scripts-repo' (contains 'scripts')
         # Config file is .golangci.yml
@@ -730,9 +733,10 @@ RSpec.describe(GHB::LinterJobBuilder) do
           )
         )
 
-        # Only match eslint pattern (js files)
+        # Only match eslint pattern. Match `(js|mjs|cjs)` -- unique to eslint;
+        # Semgrep's catch-all has the bare tokens but never that exact grouping.
         allow(builder).to(receive(:find_files_matching).and_return([]))
-        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('js')), anything).and_return(['app.js']))
+        allow(builder).to(receive(:find_files_matching).with(anything, an_object_having_attributes(source: a_string_including('(js|mjs|cjs)')), anything).and_return(['app.js']))
 
         # No script_path, but local linters/ directory has the config
         allow(File).to(receive(:exist?).with('linters/.eslintrc.json').and_return(true))


### PR DESCRIPTION
## Summary

Extends the centralized, sentinel-delimited excluded-dirs management (driven by `config/languages.yaml`) to three more linter configs that were previously shipped as static, preserved files: Semgrep's `.semgrepignore`, cfn-lint's `.cfnlintrc`, and SwiftLint's `.swiftlint.yml`. Each now carries a `# ghb:excluded-dirs:start/end` managed block that github-build renders from the canonical excluded-dirs list in the config's native syntax, so the ignore list stays aligned across every linter from a single source. With these configs now managed, `preserve_config: true` is dropped from Semgrep and SwiftLint, leaving Trivy's `.trivyignore` as the only preserved config.

**Key changes:**

- Add `body_semgrepignore`, `body_cfnlint`, and `body_swiftlint` renderers to `LinterIgnoreRenderer` and register `.semgrepignore`, `.cfnlintrc`, and `.swiftlint.yml` in `FORMATS`
- Wrap the dependency-directory lists in `config/linters/.semgrepignore`, `.cfnlintrc`, and `.swiftlint.yml` with managed sentinels; SwiftLint keeps its Swift-specific extras outside the block
- Add the `**/*.workflow.js` exclusion to the top-level `.semgrepignore`
- Remove `preserve_config: true` from the Semgrep and SwiftLint entries in `config/linters.yaml`; update the `preserve_config` doc comment to reference Trivy/`.trivyignore`
- Update `docs/architecture.md` to list the three newly managed configs and their rendering syntax
- Add renderer specs for the three new formats and retarget the `linter_job_builder` preserve_config specs to Trivy; tighten linter-pattern matchers to unique alternation groups
- Bump `json` gem 2.19.7 → 2.19.8 in `Gemfile.lock`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified