### PR TITLE
Document optional linter config keys and bump PHP to 8.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,11 @@ own copy. Required top-level keys are validated at startup — a missing key fai
 #### Linters (`--linters_config_file`, default `config/linters.yaml`)
 
 A map of linter id → definition. Each entry **must** define `short_name`, `long_name`, `uses`, `path`, and
-`pattern`. Optional keys: `condition` (a GitHub Actions `if:` expression), `config` (linter config file to copy).
+`pattern`. Optional keys: `condition` (a GitHub Actions `if:` expression), `config` (a single config file name or
+a list of names when a linter ships several, e.g. Trivy's `["trivy.yaml", ".trivyignore"]`), `preserve_config`
+(keep the project's existing config instead of overwriting it), `content_match` / `content_match_pattern` (filter
+matched files by their contents), `permissions` (job-level permissions override), and `directory` (extra directory
+hint).
 
 ```yaml
 actionlint:
@@ -136,7 +140,7 @@ actionlint:
   path: ".github/workflows"
   pattern: ".*\\.(yml|yaml)$"
   condition: "github.event_name == 'pull_request'" # optional
-  config:                                           # optional
+  config:                                           # optional (string or list)
 ```
 
 #### Languages (`--languages_config_file`, default `config/languages.yaml`)

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -253,7 +253,7 @@ php:
     - .php-version
   setup_options:
     - name: php-version
-      value: 8.5.6
+      value: 8.5.7
     - name: php-version-file
       value:
     - name: php-extensions


### PR DESCRIPTION
## Summary

Expands the linter configuration documentation in the README to cover the
optional keys that have been added over recent changes, and bumps the default
PHP version used by the build.

**Key changes:**

- Document additional optional linter keys: `config` accepting a single name or
  a list (e.g. Trivy's `["trivy.yaml", ".trivyignore"]`), `preserve_config`,
  `content_match` / `content_match_pattern`, `permissions`, and `directory`.
- Annotate the `config:` example line to note it accepts a string or a list.
- Bump the default PHP version in `config/languages.yaml` from 8.5.6 to 8.5.7.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation and version-bump only; no code logic changed
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified