### PR TITLE
Add repo-managed trivy.yaml with shared scan skip-dirs

### DIFF
--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,39 @@
+# Trivy scanner configuration
+# https://trivy.dev/latest/docs/references/configuration/config-file/
+#
+# scan.skip-dirs lists directories Trivy ignores. The block between the
+# ghb:excluded-dirs sentinels is managed by github-build from
+# config/languages.yaml -- do not edit it by hand. Add your own project-specific
+# directories OUTSIDE the sentinels (e.g. below the end marker); they are
+# preserved across rebuilds.
+#
+# Vulnerability/CVE IDs to ignore go in .trivyignore, not here.
+scan:
+  skip-dirs:
+    # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
+    - "**/.build"
+    - "**/.bundle"
+    - "**/.git"
+    - "**/.gradle"
+    - "**/.hg"
+    - "**/.m2"
+    - "**/.npm"
+    - "**/.pnpm"
+    - "**/.pytest_cache"
+    - "**/.svn"
+    - "**/.venv"
+    - "**/.yarn"
+    - "**/__pycache__"
+    - "**/build"
+    - "**/Carthage"
+    - "**/coverage"
+    - "**/DerivedData"
+    - "**/dist"
+    - "**/env"
+    - "**/Libraries"
+    - "**/node_modules"
+    - "**/Pods"
+    - "**/target"
+    - "**/vendor"
+    - "**/venv"
+    # ghb:excluded-dirs:end


### PR DESCRIPTION
## Summary

Adds a root-level `trivy.yaml` to this repository, applying github-build's own merge-managed Trivy configuration to itself. The file carries the shared `scan.skip-dirs` list rendered from `config/languages.yaml` between the `ghb:excluded-dirs` sentinels, matching the behavior the build already ships to target repos (and complementing the existing tracked `.trivyignore`).

**Key changes:**

- Add `trivy.yaml` with `scan.skip-dirs` populated from the managed `ghb:excluded-dirs` block (`.build`, `.git`, `node_modules`, `vendor`, `dist`, `target`, etc.)
- Include header guidance documenting that the sentinel block is managed by github-build and that project-specific dirs belong outside the sentinels, with CVE/vuln IDs going in `.trivyignore`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Static scanner config file with no runtime logic
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified