### PR TITLE
Detect sub-project lockfiles two levels deep by default; remove --mono_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ options
                                      Ignore linter keys in linter config file
         --languages_config_file file Path to languages config file
         --linters_config_file file   Path to linters config file
-        --mono_repo                  Scan one level deep for language dependency files
         --options-apt file           Path to APT options file
         --options-mongodb file       Path to MongoDB options file
         --options-mysql file         Path to MySQL options file

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,6 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `ignored_linters`: Hash of linters to skip
 - `languages_config_file`: Path to languages config file
 - `linters_config_file`: Path to linters config file
-- `mono_repo`: Scan one level deep for language dependency files
 - `options_config_file_apt`: Path to APT options config
 - `options_config_file_mongodb`: Path to MongoDB options config
 - `options_config_file_mysql`: Path to MySQL options config
@@ -329,7 +328,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 ### GHB::LanguageJobBuilder
 
-**Purpose:** Detects programming languages based on file extensions and dependency files, then creates unit test workflow jobs with appropriate setup, package manager, and test framework steps. Supports mono-repo mode with per-subdirectory steps.
+**Purpose:** Detects programming languages based on file extensions and dependency files, then creates unit test workflow jobs with appropriate setup, package manager, and test framework steps. Sub-projects whose dependency files sit up to two directory levels below the repo root are detected by default and generate per-subdirectory steps.
 
 **Location:** `lib/ghb/language_job_builder.rb`
 
@@ -622,8 +621,8 @@ All dependencies are managed via Bundler with versions locked in `Gemfile.lock`.
 1. Loads language and options configurations from YAML files
 2. For each language entry (skipping non-Hash values like `excluded_dirs`), uses pure Ruby `find_files_matching` to search for files matching the language's file extension
 3. Verifies dependency files exist (e.g., `go.mod`, `package.json`)
-4. In mono-repo mode, scans one level deep for subdirectory dependency files and generates per-subdirectory package manager and test steps
-5. Checks dependency files (including subdirectory files in mono-repo mode) for database dependencies (MongoDB, MySQL, Redis, Elasticsearch) using `file_contains?`
+4. Scans up to two directory levels below the repo root for sub-project dependency files (excluding vendored/ignored directories) and generates per-subdirectory package manager and test steps
+5. Checks dependency files (including sub-project files) for database dependencies (MongoDB, MySQL, Redis, Elasticsearch) using `file_contains?`
 6. Detects version files (`.ruby-version`, `.nvmrc`, etc.) and validates against recommended versions
 7. Merges setup options with version validation (strict mode auto-updates version files and env vars to recommended values, non-strict warns)
 8. Creates unit test workflow job with appropriate setup, package manager, and test steps

--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -11,7 +11,10 @@ module GHB
     SWIFT_DEPLOY_CHECK_FLAGS = %w[DEPLOY_ON_BETA DEPLOY_ON_RC DEPLOY_ON_PROD DEPLOY_MACOS DEPLOY_TVOS].freeze
     # Languages whose dependency steps must also be staged as CodeDeploy pre-steps.
     CODEDEPLOY_SETUP_LANGUAGES = %w[go php].freeze
-    private_constant :SWIFT_DEPLOY_CHECK_FLAGS, :CODEDEPLOY_SETUP_LANGUAGES
+    # How many directory levels below the repo root a sub-project dependency file
+    # may sit and still be detected (e.g. js/<module>/package-lock.json is 2 deep).
+    SUBDIR_DEPENDENCY_SCAN_DEPTH = 2
+    private_constant :SWIFT_DEPLOY_CHECK_FLAGS, :CODEDEPLOY_SETUP_LANGUAGES, :SUBDIR_DEPENDENCY_SCAN_DEPTH
 
     attr_reader :code_deploy_pre_steps, :dependencies_steps, :dependencies_commands
 
@@ -80,11 +83,7 @@ module GHB
         language[:dependencies].each do |dependency|
           dependency_detected = true if File.file?(dependency[:dependency_file])
 
-          next unless @options.mono_repo
-
-          Dir.glob("*/#{dependency[:dependency_file]}").each do |found|
-            mono_dependency_locations << { dependency: dependency, subdir: File.dirname(found), path: found }
-          end
+          mono_dependency_locations.concat(find_subdir_dependencies(dependency, excluded_paths))
         end
 
         dependency_detected = true if mono_dependency_locations.any?
@@ -125,6 +124,25 @@ module GHB
       add_setup_options(setup_options, service_options[:elasticsearch]) if elasticsearch
 
       add_language_job(language, setup_options, version_file, mono_dependency_locations)
+    end
+
+    # Find a language's dependency lockfile in sub-project directories. Scans up to
+    # SUBDIR_DEPENDENCY_SCAN_DEPTH levels below the repo root, skipping the root
+    # itself (detected separately) and any excluded/vendored directory. Replaces the
+    # former `--mono_repo`-gated one-level glob: sub-project detection is now default.
+    def find_subdir_dependencies(dependency, excluded_paths)
+      # find_files_matching yields root-relative paths ("./sub/file"), where a file
+      # directly under the start dir is depth 1; a file N directories deep is depth
+      # N+1. Allow one extra so SUBDIR_DEPENDENCY_SCAN_DEPTH counts subdir levels.
+      pattern = Regexp.new("/#{Regexp.escape(dependency[:dependency_file])}\\z")
+      matches = find_files_matching('.', pattern, excluded_paths, max_depth: SUBDIR_DEPENDENCY_SCAN_DEPTH + 1)
+
+      matches.filter_map do |found|
+        next if File.dirname(found) == '.' # repo root is detected separately via File.file?
+
+        relative = found.delete_prefix('./')
+        { dependency: dependency, subdir: File.dirname(relative), path: relative }
+      end
     end
 
     # True for languages that get the extended Swift deploy `if:` checks.

--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -35,7 +35,6 @@ module GHB
       @skip_gitignore = false
       @skip_license_check = false
       @skip_repository_settings = false
-      @mono_repo = false
       @get_ignored_folders = false
       @skip_slack = false
       @strict_version_check = true
@@ -44,7 +43,7 @@ module GHB
       setup_parser
     end
 
-    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :mono_repo, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check, :sync_required_status_checks
+    attr_reader :application_name, :build_file, :excluded_folders, :force_codedeploy_setup, :get_ignored_folders, :gitignore_config_file, :ignored_linters, :languages_config_file, :linters_config_file, :options_config_file_apt, :options_config_file_elasticsearch, :options_config_file_mongodb, :options_config_file_mysql, :options_config_file_redis, :organization, :original_argv, :skip_gitignore, :skip_license_check, :skip_repository_settings, :skip_semgrep, :skip_slack, :strict_version_check, :sync_required_status_checks
 
     def parse
       @parser.parse!(@argv)
@@ -153,10 +152,6 @@ module GHB
         ignored_linters.split(',').each do |key|
           @ignored_linters[key.to_sym] = true
         end
-      end
-
-      @parser.on('', '--mono_repo', 'Scan one level deep for language dependency files') do
-        @mono_repo = true
       end
 
       @parser.on('', '--no_strict_version_check', 'Do not auto-update when VERSION options do not match recommended defaults') do

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
   let(:mock_options) do
     instance_double(
       GHB::Options,
-      mono_repo: false,
       excluded_folders: [],
       skip_license_check: true,
       force_codedeploy_setup: false,
@@ -296,7 +295,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'prints warning but does not exit when version file mismatches and strict_version_check is false' do # rubocop:disable RSpec/ExampleLength
       non_strict_options = instance_double(
         GHB::Options,
-        mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
         force_codedeploy_setup: false,
@@ -338,7 +336,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'populates code_deploy_pre_steps when force_codedeploy_setup is true' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       codedeploy_options = instance_double(
         GHB::Options,
-        mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
         force_codedeploy_setup: true,
@@ -380,7 +377,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'prints warning when existing env value differs from option value' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       non_strict_options = instance_double(
         GHB::Options,
-        mono_repo: false,
         excluded_folders: [],
         skip_license_check: true,
         force_codedeploy_setup: false,
@@ -472,7 +468,6 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
     it 'adds Licenses step when Podfile.lock exists and skip_license_check is false' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       license_options = instance_double(
         GHB::Options,
-        mono_repo: false,
         excluded_folders: [],
         skip_license_check: false,
         force_codedeploy_setup: false,
@@ -515,43 +510,16 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       expect(licenses_step.with).to(have_key(:'ssh-key'))
     end
 
-    it 'detects mono_repo subdirectory dependencies and adds per-subdir steps' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      mono_options = instance_double(
-        GHB::Options,
-        mono_repo: true,
-        excluded_folders: [],
-        skip_license_check: true,
-        force_codedeploy_setup: false,
-        strict_version_check: true,
-        languages_config_file: 'config/languages.yaml',
-        options_config_file_apt: 'config/options/apt.yaml',
-        options_config_file_mongodb: 'config/options/mongodb.yaml',
-        options_config_file_mysql: 'config/options/mysql.yaml',
-        options_config_file_redis: 'config/options/redis.yaml',
-        options_config_file_elasticsearch: 'config/options/elasticsearch.yaml'
-      )
+    it 'detects sub-project dependency files by default and adds per-subdir steps' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      stub_non_strict_config_file_reads(builder, go_language_yaml)
 
-      mono_builder = described_class.new(
-        context: GHB::BuildContext.new(
-          options: mono_options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: {}
-        ),
-        unit_tests_conditions: unit_tests_conditions,
-        dependencies_commands: +''
-      )
-
-      stub_non_strict_config_file_reads(mono_builder, go_language_yaml)
-
-      allow(mono_builder).to(receive_messages(find_files_matching: ['./main.go'], file_contains?: false))
+      allow(builder).to(receive_messages(file_contains?: false, find_files_matching: ['./main.go']))
+      allow(builder).to(receive(:find_files_matching).with(anything, anything, anything, max_depth: anything).and_return(['./svc-a/go.mod']))
       allow(File).to(receive(:file?).with('go.mod').and_return(false))
       allow(File).to(receive(:exist?).with('.go-version').and_return(false))
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
-      allow(Dir).to(receive(:glob).with('*/go.mod').and_return(['svc-a/go.mod']))
 
-      mono_builder.build
+      builder.build
 
       job = new_workflow.jobs[:go_unit_tests]
       step_names = job.steps.map(&:name)
@@ -559,44 +527,35 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       expect(step_names).to(include('Testing (svc-a)'))
     end
 
-    it 'detects services in mono_repo subdirectory dependency files' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
-      mono_options = instance_double(
-        GHB::Options,
-        mono_repo: true,
-        excluded_folders: [],
-        skip_license_check: true,
-        force_codedeploy_setup: false,
-        strict_version_check: true,
-        languages_config_file: 'config/languages.yaml',
-        options_config_file_apt: 'config/options/apt.yaml',
-        options_config_file_mongodb: 'config/options/mongodb.yaml',
-        options_config_file_mysql: 'config/options/mysql.yaml',
-        options_config_file_redis: 'config/options/redis.yaml',
-        options_config_file_elasticsearch: 'config/options/elasticsearch.yaml'
-      )
+    it 'scans sub-project dependency files up to two directory levels deep' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      stub_non_strict_config_file_reads(builder, go_language_yaml)
 
-      mono_svc_builder = described_class.new(
-        context: GHB::BuildContext.new(
-          options: mono_options,
-          submodules: submodules,
-          old_workflow: old_workflow,
-          new_workflow: new_workflow,
-          file_cache: {}
-        ),
-        unit_tests_conditions: unit_tests_conditions,
-        dependencies_commands: +''
-      )
-
-      stub_non_strict_config_file_reads(mono_svc_builder, go_language_yaml)
-
-      allow(mono_svc_builder).to(receive_messages(find_files_matching: ['./main.go'], file_contains?: false))
-      allow(mono_svc_builder).to(receive(:file_contains?).with('svc-a/go.mod', 'mongodb').and_return(true))
+      allow(builder).to(receive_messages(file_contains?: false, find_files_matching: ['./main.go']))
+      allow(builder).to(receive(:find_files_matching).with(anything, anything, anything, max_depth: anything).and_return(['./apps/web/go.mod']))
       allow(File).to(receive(:file?).with('go.mod').and_return(false))
       allow(File).to(receive(:exist?).with('.go-version').and_return(false))
       allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
-      allow(Dir).to(receive(:glob).with('*/go.mod').and_return(['svc-a/go.mod']))
 
-      mono_svc_builder.build
+      builder.build
+
+      # max_depth 3 == repo root + two subdirectory levels (a 2-level path is depth 3).
+      expect(builder).to(have_received(:find_files_matching).with('.', anything, anything, max_depth: 3))
+      step_names = new_workflow.jobs[:go_unit_tests].steps.map(&:name)
+      expect(step_names).to(include('Go Modules (apps/web)'))
+      expect(step_names).to(include('Testing (apps/web)'))
+    end
+
+    it 'detects services in sub-project dependency files' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      stub_non_strict_config_file_reads(builder, go_language_yaml)
+
+      allow(builder).to(receive_messages(file_contains?: false, find_files_matching: ['./main.go']))
+      allow(builder).to(receive(:find_files_matching).with(anything, anything, anything, max_depth: anything).and_return(['./svc-a/go.mod']))
+      allow(builder).to(receive(:file_contains?).with('svc-a/go.mod', 'mongodb').and_return(true))
+      allow(File).to(receive(:file?).with('go.mod').and_return(false))
+      allow(File).to(receive(:exist?).with('.go-version').and_return(false))
+      allow(File).to(receive(:exist?).with('Podfile.lock').and_return(false))
+
+      builder.build
 
       expect(new_workflow.jobs).to(have_key(:go_unit_tests))
       expect(new_workflow.env).to(have_key(:'MONGODB-VERSION'))


### PR DESCRIPTION
## Summary

Sub-project dependency detection is now on by default instead of being gated behind `--mono_repo`, and it scans deeper. Previously a unit-test job was only generated for a language when its lockfile sat at the repo root, or — with `--mono_repo` — exactly one directory deep. Real layouts nest a level further (e.g. `js/<module>/package-lock.json`), so those projects were silently never detected and got no CI test job. This makes root + up to two subdirectory levels the default and removes the now-redundant flag.

**Key changes:**

- `lib/ghb/language_job_builder.rb`: removed the `--mono_repo` gate; sub-project scanning is always on via a new `find_subdir_dependencies` helper that uses `find_files_matching` with `max_depth` (root + up to 2 subdirectory levels, `SUBDIR_DEPENDENCY_SCAN_DEPTH = 2`). Replacing the old `Dir.glob("*/lockfile")` also means lockfile detection now reuses the shared exclusions (`node_modules`, `dist`, `vendor`, submodules, `excluded_folders`).
- `lib/ghb/options.rb`: deleted the `--mono_repo` option, its ivar, and the attr_reader entry.
- `spec/ghb/language_job_builder_spec.rb`: dropped `mono_repo:` from the option doubles, rewrote the two subdirectory specs for the no-flag API, and added a spec that locks the two-level depth contract (asserts the `max_depth: 3` scan and a 2-level per-subdir step).
- `README.md` / `docs/architecture.md`: removed the `--mono_repo` usage/option entries and updated the LanguageJobBuilder description and detection flow to "scans up to two levels deep by default."

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [x] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments

This is a breaking change in two ways. First, the `--mono_repo` CLI flag is removed: any wrapper or script still passing it will now fail with an OptionParser "invalid option" error and must drop the flag (its behavior is now the default). Second, the default generated workflow changes for any repo that has dependency lockfiles in subdirectories up to two levels deep — those sub-projects now produce per-subdirectory install and unit-test steps on the next sync where they previously produced none. Detection reuses the existing exclusions, so vendored/ignored directories (`node_modules`, `vendor`, etc.) are still pruned. Note: generated JS test steps still run the framework default (`npx jest`); switching that to `npm test` is a separate follow-up.