### PR TITLE
Run JavaScript repo's own npm test script instead of hardcoded jest

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -152,8 +152,8 @@ js:
       package_manager_default: pnpm install
       package_manager_update: pnpm update
       dependabot_ecosystem: npm
-  unit_test_framework_name: Jest
-  unit_test_framework_default: npx jest
+  unit_test_framework_name: Unit Tests
+  unit_test_framework_default: npm test --if-present
 kotlin:
   short_name: kotlin
   long_name: Kotlin


### PR DESCRIPTION
## Summary

The generated JavaScript unit-test step ran a hardcoded `npx jest`, which fails for any repo that doesn't use Jest (e.g. ones using Node's built-in `node:test`, Vitest, or Mocha) and runs nothing meaningful where Jest isn't installed. This changes the JavaScript test framework default to delegate to the repo's own `test` script via `npm test --if-present`, so each project's configured runner is used.

**Key changes:**

- `config/languages.yaml`: for the `js` language, `unit_test_framework_default` is now `npm test --if-present` (was `npx jest`) and `unit_test_framework_name` is now `Unit Tests` (was `Jest`).

`--if-present` makes the step a clean no-op for JavaScript sub-projects that have no `test` script (e.g. Lambda functions), so the now-default sub-project detection doesn't produce spurious failing jobs. Verified locally: `npm test --if-present` runs the `test` script when present (confirmed with a `node --test` script) and exits 0 when absent.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Single-value config change in `config/languages.yaml`; no spec asserts the JS test command, and the behavior (`npm test --if-present`) was verified manually. The existing 402-example suite still passes.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified