### PR TITLE
Make sub-project dependency-update commands cd into their folder

### DIFF
--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -283,7 +283,10 @@ module GHB
           do_shell('bash')
           do_run("cd #{subdir} && #{dep[:package_manager_default]}") if run.nil?
           env['GITHUB_TOKEN'] = '${{secrets.GH_PAT}}'
-          dependencies_commands_additions << dep[:package_manager_update] if dep[:package_manager_update]
+          # Sub-project update commands run from the repo root in a single combined
+          # block, so each must cd into its own folder; a subshell keeps the cwd
+          # local so the next command still starts from the root.
+          dependencies_commands_additions << "(cd #{subdir} && #{dep[:package_manager_update]})" if dep[:package_manager_update]
         end
 
         job.do_step("#{language[:unit_test_framework_name]} (#{subdir})") do

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -525,6 +525,9 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       step_names = job.steps.map(&:name)
       expect(step_names).to(include('Go Modules (svc-a)'))
       expect(step_names).to(include('Testing (svc-a)'))
+      # The dependency-update command must cd into the sub-project folder (in a
+      # subshell) rather than running at the repo root where there is no manifest.
+      expect(builder.dependencies_commands).to(include('(cd svc-a && go mod tidy)'))
     end
 
     it 'scans sub-project dependency files up to two directory levels deep' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations


### PR DESCRIPTION
## Summary

The generated "Update Dependencies" step runs each detected package manager's update command (e.g. `npm upgrade`) in one combined block at the repo root. For sub-project dependencies (e.g. `js/<module>/package-lock.json`), the update command was appended verbatim with no folder awareness, so a repo with two Node sub-projects produced two bare `npm upgrade` lines back-to-back that both run at the root — where there is no `package.json`, so neither does anything.

This makes sub-project update commands `cd` into their own folder, in a subshell so the working directory resets for the next command in the combined block.

**Key changes:**

- `lib/ghb/language_job_builder.rb`: in `build_mono_dependency_steps`, append `(cd <subdir> && <package_manager_update>)` to `dependencies_commands` instead of the bare update command. Root-level dependencies (in `build_dependency_steps`) are unchanged — they correctly run at the repo root.
- `spec/ghb/language_job_builder_spec.rb`: assert the sub-project update command is folder-aware (`(cd svc-a && go mod tidy)`).

For example, an aws-style repo with `js/ami-garbage-collector` and `js/env-start-stop` now generates:

```
(cd js/ami-garbage-collector && npm upgrade)
(cd js/env-start-stop && npm upgrade)
```

instead of two bare `npm upgrade` lines that fail at the root.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified