### PR TITLE
Exclude gitignored files/folders from detection scans

### DIFF
--- a/lib/ghb/file_scanner.rb
+++ b/lib/ghb/file_scanner.rb
@@ -55,8 +55,11 @@ module GHB
         end
 
         # Skip excluded paths (submodules, excluded_folders, dirs from languages.yaml)
+        # and anything the repo's .gitignore excludes (e.g. the .ruby-lsp sub-bundle),
+        # so ignored files never count toward language/dependency/linter detection.
         should_skip = excluded_paths.any? { |excluded| file_path.include?(excluded) } ||
-                      config_excluded.any? { |dir| file_path.include?("/#{dir}/") }
+                      config_excluded.any? { |dir| file_path.include?("/#{dir}/") } ||
+                      git_ignored?(file_path)
 
         if should_skip
           Find.prune
@@ -71,6 +74,44 @@ module GHB
     rescue Errno::ENOENT, Errno::EACCES
       # Path doesn't exist or permission denied - return empty
       []
+    end
+
+    # Returns true when the repo's .gitignore (plus global/exclude rules) ignores
+    # this path, so gitignored files/folders are never scanned for detection.
+    # Paths are matched relative to the repo root, mirroring `git ls-files` output.
+    # @param file_path [String] path yielded by Find (e.g. "./.ruby-lsp/Gemfile")
+    # @return [Boolean] true if the path is git-ignored
+    def git_ignored?(file_path)
+      ignored = gitignored_paths
+      return false if ignored.empty?
+
+      relative = file_path.delete_prefix('./')
+
+      ignored.any? do |entry|
+        if entry.end_with?('/')
+          directory = entry.chomp('/')
+          relative == directory || relative.start_with?("#{directory}/")
+        else
+          relative == entry
+        end
+      end
+    end
+
+    # Git-ignored files and directories relative to the repo root, computed once.
+    # Uses `git ls-files` so the real .gitignore semantics apply (negations,
+    # nested .gitignore files, global excludes). Returns [] when git is
+    # unavailable or the cwd is not a repository, leaving scanning unfiltered.
+    # @return [Array<String>] ignored entries; directories carry a trailing slash
+    def gitignored_paths
+      return @gitignored_paths if defined?(@gitignored_paths)
+
+      output = `git ls-files --others --ignored --exclude-standard --directory 2>/dev/null`
+      entries = output.split("\n")
+      entries.map!(&:strip)
+      entries.reject!(&:empty?)
+      @gitignored_paths = entries
+    rescue StandardError
+      @gitignored_paths = []
     end
 
     # Pure Ruby file content search

--- a/spec/ghb/file_scanner_spec.rb
+++ b/spec/ghb/file_scanner_spec.rb
@@ -102,6 +102,21 @@ RSpec.describe(GHB::FileScanner) do
       expect(matches).to(eq([]))
     end
 
+    it 'skips files and folders ignored by the repo .gitignore' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      Dir.mktmpdir('ghb-gitignore-test') do |repo|
+        system('git', 'init', '--quiet', repo, out: File::NULL, err: File::NULL)
+        File.write("#{repo}/.gitignore", ".ruby-lsp/\n")
+        FileUtils.mkdir_p("#{repo}/.ruby-lsp")
+        File.write("#{repo}/.ruby-lsp/Gemfile", "source 'x'\n")
+        File.write("#{repo}/app.rb", "puts 'hi'\n")
+
+        matches = Dir.chdir(repo) { scanner.find_files_matching('.', /(\.rb|Gemfile)$/, []) } # rubocop:disable ThreadSafety/DirChdir
+
+        expect(matches).to(include('./app.rb'))
+        expect(matches).not_to(include('./.ruby-lsp/Gemfile'))
+      end
+    end
+
     it 'handles permission denied gracefully' do # rubocop:disable RSpec/ExampleLength
       skip 'Cannot test permission denied as root' if Process.uid.zero? # rubocop:disable RSpec/Pending
 


### PR DESCRIPTION
# Summary

`find_files_matching` (the shared scanner behind language, sub-project dependency, and linter detection) only skipped `--excluded_folders`, submodules, and the excluded/install dirs from `languages.yaml`. It never consulted the repo's `.gitignore`, so a gitignored bundle like `.ruby-lsp/` — which ships its own `Gemfile` — was scanned and wrongly detected as a Ruby sub-project. This is what produced [Cloud-Officer/aws#1024](https://github.com/Cloud-Officer/aws/pull/1024), where `.ruby-lsp` got wired into `build.yml` and `dependencies.yml`.

This change honors the repo's actual ignore status by pruning anything `git ls-files --others --ignored --exclude-standard --directory` reports. That applies real `.gitignore` semantics (nested ignore files, global excludes, negations) instead of re-implementing them. It degrades gracefully to no filtering when git is unavailable or the cwd is not a repository. The fixed git command takes no interpolated input, so the SEC-001/002 injection concerns behind the pure-Ruby scanner do not apply (and the codebase already shells to `git`, e.g. `application.rb#detect_default_branch`).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

New `file_scanner_spec` test spins up a real git repo with a gitignored `.ruby-lsp/` containing a `Gemfile` and asserts it is skipped while a tracked `app.rb` is still found. Full suite: 403 examples, 0 failures; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)