### PR TITLE
Run exit-code linters on push, keep reviewdog linters PR-only

### DIFF
--- a/config/linters.yaml
+++ b/config/linters.yaml
@@ -59,7 +59,9 @@ bandit:
 cfnlint:
   short_name: Cfn-lint
   long_name: CloudFormation Linter
-  condition: "github.event_name == 'pull_request'"
+  # No condition: cfn-lint runs `--non-zero-exit-code error` and fails the job by
+  # exit code (it does not use reviewdog/github-pr-review), so it is meaningful on
+  # pushes too, not just pull requests.
   uses: cloud-officer/ci-actions/linters/cfnlint
   config: ".cfnlintrc"
   path: "."
@@ -161,7 +163,9 @@ rubocop:
 semgrep:
   short_name: Semgrep
   long_name: Semgrep Security Scanner
-  condition: "github.event_name == 'pull_request'"
+  # No condition: Semgrep runs `semgrep scan ... --error` and fails the job by exit
+  # code (no reviewdog/github-pr-review), so this security scan is meaningful on
+  # pushes too, not just pull requests.
   uses: cloud-officer/ci-actions/linters/semgrep
   config: ".semgrepignore"
   path: "."
@@ -187,7 +191,9 @@ swiftlint:
 trivy:
   short_name: Trivy
   long_name: Container & IaC Vulnerability Scanner
-  condition: "github.event_name == 'pull_request'"
+  # No condition: the Trivy action runs the scanner with `exit-code: 1` and fails
+  # the job by exit code (no reviewdog/github-pr-review), so this vulnerability
+  # scan is meaningful on pushes too, not just pull requests.
   uses: cloud-officer/ci-actions/linters/trivy
   # trivy.yaml carries the shared excluded-dirs (scan.skip-dirs) and is managed by
   # LinterIgnoreRenderer; project-specific skip-dirs added outside its sentinel

--- a/spec/fixtures/workflow_generation/build.yml
+++ b/spec/fixtures/workflow_generation/build.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Semgrep

--- a/spec/ghb/linters_config_spec.rb
+++ b/spec/ghb/linters_config_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Guards the per-linter `condition` in config/linters.yaml against catalog drift
+# (the root cause of CI-010): a linter job should carry the
+# `github.event_name == 'pull_request'` guard ONLY when it needs a pull request
+# to be meaningful, i.e. it reports through reviewdog's github-pr-review reporter.
+# Linters that fail the job by exit code work on pushes too and must run
+# unconditionally so regressions on master/tags/dependabot are still caught.
+RSpec.describe('config/linters.yaml conditions') do # rubocop:disable RSpec/DescribeClass
+  let(:linters) do
+    Psych.safe_load(File.read("#{__dir__}/../../config/linters.yaml")).transform_keys(&:to_sym)
+  end
+
+  # reviewdog/github-pr-review reporters -> require a PR.
+  let(:pr_only) { %i[actionlint eslint flake8 golangci hadolint ktlint markdownlint pmd protolint rubocop shellcheck yamllint] }
+
+  # Exit-code linters -> meaningful on every event, no PR guard.
+  let(:run_always) { %i[bandit cfnlint phpcs phpstan semgrep swiftlint trivy] }
+
+  it 'lists exactly the known linters (a new linter must be classified explicitly)' do
+    expect(linters.keys.sort).to(eq((pr_only + run_always).sort))
+  end
+
+  it 'guards every reviewdog linter with the pull_request condition' do
+    conditions = pr_only.map { |name| linters[name]['condition'] }
+    expect(conditions).to(all(eq("github.event_name == 'pull_request'")))
+  end
+
+  it 'runs every exit-code linter on all events (no condition)' do
+    conditions = run_always.map { |name| linters[name]['condition'] }
+    expect(conditions).to(all(be_nil))
+  end
+end


### PR DESCRIPTION
## Summary

Capability-based linter job conditions (serves ci-actions CI-010 / cloud-officer/ci-actions#239). A linter job should carry the `github.event_name == 'pull_request'` guard ONLY when it needs a PR to be meaningful — i.e. it reports through reviewdog's `github-pr-review` reporter. Linters that fail the job by exit code work on pushes too (master, tags, dependabot) and should run unconditionally so regressions there are still caught.

**Key changes:**

- `config/linters.yaml`: removed the `condition: "github.event_name == 'pull_request'"` from the exit-code linters **cfnlint, semgrep, trivy** (each with an explanatory comment). bandit/phpcs/phpstan/swiftlint were already condition-free. The 12 reviewdog linters (actionlint, eslint, flake8, golangci, hadolint, ktlint, markdownlint, pmd, protolint, rubocop, shellcheck, yamllint) keep the guard.
- `spec/ghb/linters_config_spec.rb` (new): asserts exactly the 12 reviewdog linters carry the guard and the 7 exit-code linters don't — locks the split against the catalog drift that was CI-010's root cause.
- `spec/fixtures/workflow_generation/build.yml`: regenerated golden file (semgrep loses the guard).

rspec 406 examples / 0 failures; rubocop clean.