### PR TITLE
Fix #444: tolerate removed --mono_repo flag in persisted build.yml headers

### DIFF
--- a/lib/ghb/options.rb
+++ b/lib/ghb/options.rb
@@ -10,8 +10,13 @@ module GHB
     ARGS_COMMENT_PREFIX = '# github-build'
     # Flags that are one-shot in nature and must not be persisted to the generated workflow header.
     EPHEMERAL_FLAGS = %w[--sync_required_status_checks].freeze
+    # Flags removed from the CLI that may still linger in a downstream repo's persisted build.yml header.
+    # They are stripped (with a warning) during persisted-args replay so old headers self-heal on the next
+    # regeneration instead of aborting on OptionParser::InvalidOption.
+    REMOVED_FLAGS = %w[--mono_repo].freeze
     private_constant :ARGS_COMMENT_PREFIX
     private_constant :EPHEMERAL_FLAGS
+    private_constant :REMOVED_FLAGS
 
     def initialize(argv = [])
       @application_name = Dir.pwd.split('/').last.split('-').last
@@ -67,9 +72,24 @@ module GHB
 
       args_string = first_line.sub(ARGS_COMMENT_PREFIX, '').strip
       require('shellwords')
-      Shellwords.split(args_string)
+      strip_removed_flags(Shellwords.split(args_string), file)
     rescue ArgumentError => e
       raise(ConfigError, "Malformed github-build args in #{file}: #{e.message}")
+    end
+
+    # Drops flags that no longer exist from persisted args so replay tolerates removed options.
+    # Each dropped flag is reported on stderr; because it never reaches @argv/@original_argv,
+    # the regenerated build.yml header self-heals (the flag disappears on the next run).
+    def strip_removed_flags(args, file)
+      removed, kept = args.partition { |arg| removed_flag?(arg) }
+      removed.each do |arg|
+        warn("Warning: ignoring removed option '#{arg.split('=').first}' from #{file} header; it will be dropped on the next regeneration")
+      end
+      kept
+    end
+
+    def removed_flag?(arg)
+      REMOVED_FLAGS.any? { |flag| arg == flag || arg.start_with?("#{flag}=") }
     end
 
     def setup_parser

--- a/spec/ghb/options_spec.rb
+++ b/spec/ghb/options_spec.rb
@@ -321,4 +321,57 @@ RSpec.describe(GHB::Options) do
         .to(raise_error(GHB::ConfigError, /Malformed github-build args/))
     end
   end
+
+  describe 'removed flags in persisted header' do
+    it 'strips a removed flag from replayed args instead of aborting (BC-001)' do
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --organization TestOrg --mono_repo --skip_slack\n"].each))
+      allow($stderr).to(receive(:write))
+
+      options = described_class.new([])
+
+      expect(options.original_argv).to(eq(['--organization', 'TestOrg', '--skip_slack']))
+    end
+
+    it 'parses cleanly after the removed flag is stripped' do # rubocop:disable RSpec/MultipleExpectations
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --organization TestOrg --mono_repo --skip_slack\n"].each))
+      allow($stderr).to(receive(:write))
+
+      options = described_class.new([]).parse
+
+      expect(options.organization).to(eq('TestOrg'))
+      expect(options.skip_slack).to(be(true))
+    end
+
+    it 'self-heals the persisted header by dropping the removed flag from args_comment' do
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --organization TestOrg --mono_repo --skip_slack\n"].each))
+      allow($stderr).to(receive(:write))
+
+      options = described_class.new([])
+
+      expect(options.args_comment).to(eq("# github-build --organization TestOrg --skip_slack\n"))
+    end
+
+    it 'warns on stderr when a removed flag is stripped' do
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --mono_repo\n"].each))
+
+      expect { described_class.new([]) }
+        .to(output(/ignoring removed option '--mono_repo'/).to_stderr)
+    end
+
+    it 'strips a removed flag written in --flag=value form' do
+      allow(File).to(receive_messages(exist?: true, foreach: ["# github-build --mono_repo=true --skip_slack\n"].each))
+      allow($stderr).to(receive(:write))
+
+      options = described_class.new([])
+
+      expect(options.original_argv).to(eq(['--skip_slack']))
+    end
+
+    it 'still aborts when a removed flag is passed explicitly on the command line' do
+      allow(File).to(receive(:exist?).and_return(false))
+
+      expect { described_class.new(['--mono_repo']).parse }
+        .to(raise_error(OptionParser::InvalidOption))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

PR #438 removed the public `--mono_repo` CLI flag with no deprecation no-op. Because the tool persists its invocation args into each downstream repo's generated `build.yml` header (`# github-build ...`) and replays them via `Options#args_from_file`, any consumer repo whose header still contains `--mono_repo` now aborts on the next run with `OptionParser::InvalidOption: invalid option: --mono_repo`.

This makes the persisted-args replay path tolerant of removed flags, following the team's existing `EPHEMERAL_FLAGS` self-healing pattern, so old downstream headers self-heal instead of requiring a hand-edit.

Fixes #444

**Key changes:**

- Add a curated `REMOVED_FLAGS = %w[--mono_repo]` constant in `lib/ghb/options.rb`.
- `args_from_file` now strips removed flags (both `--mono_repo` and `--mono_repo=value` forms) during persisted-args replay and warns on stderr; the dropped flag never reaches `@argv`/`@original_argv`, so the regenerated header self-heals on the next run.
- CLI strictness is preserved — passing `--mono_repo` explicitly on the command line still errors; only the file-replay path tolerates it.
- Add a `removed flags in persisted header` spec context (6 cases): strip-and-replay, clean parse afterward, header self-heal via `args_comment`, the stderr warning, `--flag=value` form, and CLI still aborting.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified