### PR TITLE
Fix #445: tolerate CODEOWNERS without a catch-all line in auto-approve check

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -40,10 +40,12 @@ jobs:
           exit 0
         fi
 
-        # Collect @handles only from the catch-all (*) line — the repo-wide code owners
+        # Collect @handles only from the catch-all (*) line — the repo-wide code owners.
+        # `|| true` keeps the pipeline from aborting under `set -euo pipefail` when there
+        # is no `*` line (grep exits 1); empty handles then degrade to is_owner=false below.
         handles=$(grep -E '^\*\s' "$CODEOWNERS" \
           | grep -oE '@[A-Za-z0-9_.\-]+(/[A-Za-z0-9_.\-]+)?' \
-          | sort -u)
+          | sort -u || true)
 
         is_owner=false
         for h in $handles; do

--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -25,10 +25,12 @@ module GHB
         exit 0
       fi
 
-      # Collect @handles only from the catch-all (*) line — the repo-wide code owners
+      # Collect @handles only from the catch-all (*) line — the repo-wide code owners.
+      # `|| true` keeps the pipeline from aborting under `set -euo pipefail` when there
+      # is no `*` line (grep exits 1); empty handles then degrade to is_owner=false below.
       handles=$(grep -E '^\\*\\s' "$CODEOWNERS" \\
         | grep -oE '@[A-Za-z0-9_.\\-]+(/[A-Za-z0-9_.\\-]+)?' \\
-        | sort -u)
+        | sort -u || true)
 
       is_owner=false
       for h in $handles; do

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 RSpec.describe(GHB::AutoMergeManager) do
   let(:auto_merge_workflow) { GHB::Workflow.new('Auto-approve for code owners') }
 
@@ -146,6 +148,80 @@ RSpec.describe(GHB::AutoMergeManager) do
 
       merge_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name&.match?(/merge/i) }
       expect(merge_step).to(be_nil)
+    end
+  end
+
+  # Runs the actual generated "Check if PR author is a code owner" bash script against a
+  # sandbox CODEOWNERS file and returns [exit_status, github_output_contents, combined_stdout].
+  # The sandbox is set up via bash (not stubbed Ruby File methods) so the global File.write /
+  # FileUtils stubs above do not interfere.
+  describe 'generated CODEOWNERS check script (BUG-001)' do
+    def run_check_script(codeowners:, author:)
+      manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
+      manager.save
+      check_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name == 'Check if PR author is a code owner' }
+      script = check_step.run
+
+      Dir.mktmpdir do |dir|
+        output_path = File.join(dir, 'github_output')
+        prologue = <<~SH
+          mkdir -p '#{dir}/.github'
+          cat > '#{dir}/.github/CODEOWNERS' <<'CODEOWNERS_EOF'
+          #{codeowners}
+          CODEOWNERS_EOF
+          export GITHUB_OUTPUT='#{output_path}'
+          export AUTHOR='#{author}'
+          cd '#{dir}'
+        SH
+        stdout_str, status = Open3.capture2e('bash', '-c', "#{prologue}\n#{script}")
+        [status.exitstatus, File.exist?(output_path) ? File.read(output_path) : '', stdout_str]
+      end
+    end
+
+    it 'degrades to is_owner=false (exit 0) when CODEOWNERS has no catch-all * line' do # rubocop:disable RSpec/MultipleExpectations
+      exit_status, output, = run_check_script(codeowners: "docs/ @someone\n", author: 'alice')
+
+      expect(exit_status).to(eq(0))
+      expect(output).to(include('is_owner=false'))
+    end
+
+    it 'sets is_owner=true when the * line lists the PR author as an individual owner' do # rubocop:disable RSpec/MultipleExpectations
+      exit_status, output, = run_check_script(codeowners: "* @alice @bob\n", author: 'alice')
+
+      expect(exit_status).to(eq(0))
+      expect(output).to(include('is_owner=true'))
+    end
+
+    it 'sets is_owner=false when the * line does not list the PR author' do # rubocop:disable RSpec/MultipleExpectations
+      exit_status, output, = run_check_script(codeowners: "* @bob @carol\n", author: 'alice')
+
+      expect(exit_status).to(eq(0))
+      expect(output).to(include('is_owner=false'))
+    end
+
+    it 'degrades to is_owner=false (exit 0) when CODEOWNERS is empty' do # rubocop:disable RSpec/MultipleExpectations
+      exit_status, output, = run_check_script(codeowners: "\n", author: 'alice')
+
+      expect(exit_status).to(eq(0))
+      expect(output).to(include('is_owner=false'))
+    end
+
+    it 'still emits is_owner=false (exit 0) when no CODEOWNERS file exists' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
+      manager.save
+      check_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name == 'Check if PR author is a code owner' }
+      script = check_step.run
+
+      exit_status, output =
+        Dir.mktmpdir do |dir|
+          output_path = File.join(dir, 'github_output')
+          prologue = "export GITHUB_OUTPUT='#{output_path}'\nexport AUTHOR='alice'\ncd '#{dir}'\n"
+          _stdout_str, status = Open3.capture2e('bash', '-c', "#{prologue}#{script}")
+          [status.exitstatus, File.exist?(output_path) ? File.read(output_path) : '']
+        end
+
+      expect(exit_status).to(eq(0))
+      expect(output).to(include('is_owner=false'))
     end
   end
 end


### PR DESCRIPTION
## Summary

The `CODEOWNERS_CHECK_SCRIPT` in `lib/ghb/auto_merge_manager.rb` runs under `set -euo pipefail`. When a CODEOWNERS file exists but has no catch-all `*` line, the first `grep` in the handles pipeline exits 1, `pipefail` propagates the failure through the `$()` assignment, and `set -e` kills the step before `is_owner` is written — so the Auto-approve job shows red on every PR in those repos. The same defect is baked into every consumer repo's generated `auto-approve.yml`, including this repo's own copy.

This makes a missing `*` line degrade gracefully to `is_owner=false`, mirroring the existing "No CODEOWNERS file found" early-exit branch.

Fixes #445

**Key changes:**

- Append `|| true` to the handles pipeline in `CODEOWNERS_CHECK_SCRIPT` so it cannot abort the step under `pipefail`; empty `handles` then falls through to `is_owner=false`. Added a comment explaining why.
- Apply the same fix to this repo's own committed generated `.github/workflows/auto-approve.yml`, keeping it in sync with what the next regeneration produces. Consumer repos pick up the fix on their next `github-build` run.
- Add a `generated CODEOWNERS check script (BUG-001)` spec context that extracts the **actual generated bash** and runs it in a sandbox: no `*` line, empty file, `*` line with/without the author, and no CODEOWNERS file at all.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified