### PR TITLE
#446: remove dead ORG env var from generated code-owner check step

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -73,7 +73,6 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GH_PAT}}"
         AUTHOR: "${{github.event.pull_request.user.login}}"
-        ORG: "${{github.repository_owner}}"
     - name: Approve PR
       shell: bash
       if: steps.check.outputs.is_owner == 'true'

--- a/lib/ghb/auto_merge_manager.rb
+++ b/lib/ghb/auto_merge_manager.rb
@@ -127,8 +127,7 @@ module GHB
           do_env(
             {
               GH_TOKEN: '${{secrets.GH_PAT}}',
-              AUTHOR: '${{github.event.pull_request.user.login}}',
-              ORG: '${{github.repository_owner}}'
+              AUTHOR: '${{github.event.pull_request.user.login}}'
             }
           )
           do_run(CODEOWNERS_CHECK_SCRIPT)

--- a/spec/ghb/auto_merge_manager_spec.rb
+++ b/spec/ghb/auto_merge_manager_spec.rb
@@ -121,6 +121,23 @@ RSpec.describe(GHB::AutoMergeManager) do
       expect(check_step.env[:GH_TOKEN]).to(eq('${{secrets.GH_PAT}}'))
     end
 
+    it 'exposes only GH_TOKEN and AUTHOR to the code owner check step (no dead ORG var)' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
+      manager.save
+
+      check_step = auto_merge_workflow.jobs[:auto_approve].steps.find { |s| s.name == 'Check if PR author is a code owner' }
+      expect(check_step.env).to(
+        eq(
+          {
+            GH_TOKEN: '${{secrets.GH_PAT}}',
+            AUTHOR: '${{github.event.pull_request.user.login}}'
+          }
+        )
+      )
+      expect(check_step.env).not_to(have_key(:ORG))
+      expect(check_step.run).not_to(include('$ORG'))
+    end
+
     it 'includes an approve PR step' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       manager = described_class.new(auto_merge_workflow: auto_merge_workflow)
       manager.save


### PR DESCRIPTION
## Summary

The generated "Check if PR author is a code owner" step injected `ORG: '${{github.repository_owner}}'` into its env, but `CODEOWNERS_CHECK_SCRIPT` never references `$ORG` — team org/slug are parsed from each CODEOWNERS handle (`${entry%/*}` / `${entry#*/}`). The variable has been dead since its introducing commit and could mislead a security review into assuming team-membership lookups are scoped by repository owner when they are not.

This removes the dead variable. No behavioral change to the code-owner check logic (the pipefail defect in the same script is handled separately in #445).

Closes #446

**Key changes:**

- Drop the `ORG` entry from the check step's `do_env` hash in `lib/ghb/auto_merge_manager.rb`.
- Remove the `ORG:` line from this repo's own committed generated `.github/workflows/auto-approve.yml`, keeping it in sync with what regeneration produces. Consumer repos drop the var on their next `github-build` run.
- Add a spec asserting the check step's env is exactly `{GH_TOKEN, AUTHOR}`, contains no `:ORG` key, and the script never references `$ORG`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified