### PR TITLE
Fix #447, #448, #449: fileutils requires, CodeQL spec, untrack .idea

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -8,3 +8,10 @@
 /dataSources.local.xml
 # GitHub Copilot persisted chat sessions
 /copilot/chatSessions
+# GitHub Copilot data migration state markers (per-machine)
+/copilot.data.migration.agent.xml
+/copilot.data.migration.ask.xml
+/copilot.data.migration.ask2agent.xml
+/copilot.data.migration.edit.xml
+# GitToolbox per-machine blame state
+/git_toolbox_blame.xml

--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="AgentMigrationStateService">
-    <option name="migrationStatus" value="COMPLETED" />
-  </component>
-</project>

--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="AskMigrationStateService">
-    <option name="migrationStatus" value="COMPLETED" />
-  </component>
-</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Ask2AgentMigrationStateService">
-    <option name="migrationStatus" value="COMPLETED" />
-  </component>
-</project>

--- a/.idea/copilot.data.migration.edit.xml
+++ b/.idea/copilot.data.migration.edit.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="EditMigrationStateService">
-    <option name="migrationStatus" value="COMPLETED" />
-  </component>
-</project>

--- a/.idea/git_toolbox_blame.xml
+++ b/.idea/git_toolbox_blame.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="GitToolBoxBlameSettings">
-    <option name="version" value="2" />
-  </component>
-</project>

--- a/lib/ghb/dependabot_manager.rb
+++ b/lib/ghb/dependabot_manager.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module GHB
   # Manages dependabot configuration and cron dependency update workflow.
   class DependabotManager

--- a/lib/ghb/file_scanner.rb
+++ b/lib/ghb/file_scanner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'find'
 
 module GHB

--- a/lib/ghb/linter_job_builder.rb
+++ b/lib/ghb/linter_job_builder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require_relative 'file_scanner'
 require_relative 'linter_ignore_renderer'
 

--- a/spec/ghb/fileutils_require_spec.rb
+++ b/spec/ghb/fileutils_require_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+# Regression guard for BUG-009: files that call FileUtils must require 'fileutils'
+# themselves rather than relying on a transitive require from workflow.rb.
+#
+# Each file is loaded in a fresh Ruby process (no spec_helper, no transitive
+# requires) and asserted to define the FileUtils constant. Before the fix these
+# files loaded without FileUtils, so a standalone load raised NameError on first
+# FileUtils call; after the fix the constant is present on load.
+RSpec.describe('explicit fileutils requires (BUG-009)') do # rubocop:disable RSpec/DescribeClass
+  %w[dependabot_manager linter_job_builder file_scanner].each do |file|
+    it "defines FileUtils after loading #{file}.rb in isolation" do # rubocop:disable RSpec/MultipleExpectations
+      path = File.expand_path("../../lib/ghb/#{file}.rb", __dir__)
+      script = "require #{path.inspect}; print defined?(FileUtils).to_s"
+      stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-e', script)
+
+      expect(status).to(be_success, "load failed: #{stderr}")
+      expect(stdout).to(eq('constant'))
+    end
+  end
+end

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -1019,8 +1019,9 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
         allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil).and_return(codeql_disable_response))
       end
 
-      it 'prints CodeQL disabled confirmation for 202 response' do
-        configurator.configure
+      it 'prints CodeQL disabled confirmation for 202 response' do # rubocop:disable RSpec/MultipleExpectations
+        expect { configurator.configure }
+          .to(output(/CodeQL default setup disabled/).to_stdout)
 
         expect(github_client).to(have_received(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil))
       end
@@ -1064,8 +1065,9 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
         allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil).and_return(codeql_disable_response))
       end
 
-      it 'does not print CodeQL disabled confirmation for non-200/202 response' do
-        configurator.configure
+      it 'does not print CodeQL disabled confirmation for non-200/202 response' do # rubocop:disable RSpec/MultipleExpectations
+        expect { configurator.configure }
+          .not_to(output(/CodeQL default setup disabled/).to_stdout)
 
         expect(github_client).to(have_received(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil))
       end


### PR DESCRIPTION
## Summary

Three independent code-review cleanups from the 2026-06-10 deep review (docs/code-review.md), batched into one PR.

**Key changes:**

- **#447 (BUG-009):** Add explicit `require 'fileutils'` to `lib/ghb/dependabot_manager.rb`, `lib/ghb/file_scanner.rb`, and `lib/ghb/linter_job_builder.rb`, which called `FileUtils.*` while relying on a transitive require from `workflow.rb`. Adds `spec/ghb/fileutils_require_spec.rb`, an Open3 regression guard that loads each file in a fresh Ruby process (no spec_helper) and asserts `FileUtils` is defined.
- **#448 (TEST-001):** The two CodeQL-disabled confirmation specs in `spec/ghb/repository_configurator_spec.rb` had opposite names but byte-identical assertions, so the print/no-print branch was never verified. They now assert `.to(output(/CodeQL default setup disabled/).to_stdout)` (202) and `.not_to(...)` (non-202). No production change.
- **#449 (GIT-004):** `git rm --cached` the 5 transient per-machine `.idea/` files (4 Copilot migration markers + GitToolbox blame) and add them to `.idea/.gitignore`. Curated shared entries left tracked.

Full suite: 421 examples, 0 failures. Rubocop: no offenses.

Fixes #447
Closes #448
Closes #449

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified