### PR TITLE
Stop injecting long-lived AWS keys into generated unit-test jobs

### DIFF
--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -212,6 +212,14 @@ module GHB
         copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
         do_uses("cloud-officer/ci-actions/setup@#{CI_ACTIONS_VERSION}")
 
+        # Unit-test suites stub all AWS clients and never call AWS, so the test job
+        # must not receive long-lived AWS access keys (least privilege: handing static
+        # credentials to a job that runs dozens of third-party gems widens the blast
+        # radius of a supply-chain compromise). Strip any inherited from a previously
+        # generated workflow, and never add them to the default block below. Jobs that
+        # genuinely need AWS should use OIDC. See Cloud-Officer/ci-tools#504.
+        %i[aws-access-key-id aws-secret-access-key aws-region].each { |key| with.delete(key) }
+
         # Remove version parameter from with if version file exists (version file takes precedence)
         if version_file
           version_option_key = (version_file == '.nvmrc' ? 'node-version' : version_file.delete_prefix('.')).to_sym
@@ -222,10 +230,7 @@ module GHB
           do_with(
             {
               'ssh-key': '${{secrets.SSH_KEY}}',
-              'github-token': '${{secrets.GH_PAT}}',
-              'aws-access-key-id': '${{secrets.AWS_ACCESS_KEY_ID}}',
-              'aws-secret-access-key': '${{secrets.AWS_SECRET_ACCESS_KEY}}',
-              'aws-region': '${{secrets.AWS_DEFAULT_REGION}}'
+              'github-token': '${{secrets.GH_PAT}}'
             }.merge(setup_options)
           )
         end

--- a/spec/fixtures/workflow_generation/build.yml
+++ b/spec/fixtures/workflow_generation/build.yml
@@ -120,9 +120,6 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
-        aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
-        aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
     - name: Bundler
       shell: bash

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -122,6 +122,49 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       expect(step_names).to(include('Testing'))
     end
 
+    it 'does not grant long-lived AWS keys to the unit-test Setup step by default', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      stub_config_file_reads(go_language_yaml)
+      stub_go_language_detection
+
+      builder.build
+
+      setup = new_workflow.jobs[:go_unit_tests].steps.find { |step| step.name == 'Setup' }
+      expect(setup.with).not_to(have_key(:'aws-access-key-id'))
+      expect(setup.with).not_to(have_key(:'aws-secret-access-key'))
+      expect(setup.with).not_to(have_key(:'aws-region'))
+      expect(setup.with).to(include(:'ssh-key', :'github-token'))
+    end
+
+    it 'strips AWS keys inherited from a previously generated unit-test Setup step', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+      stub_config_file_reads(go_language_yaml)
+      stub_go_language_detection
+
+      old_workflow.do_job(:go_unit_tests) do
+        do_name('Go Unit Tests')
+        do_step('Setup') do
+          do_uses('cloud-officer/ci-actions/setup@v2')
+          do_with(
+            {
+              'ssh-key': '${{secrets.SSH_KEY}}',
+              'github-token': '${{secrets.GH_PAT}}',
+              'aws-access-key-id': '${{secrets.AWS_ACCESS_KEY_ID}}',
+              'aws-secret-access-key': '${{secrets.AWS_SECRET_ACCESS_KEY}}',
+              'aws-region': '${{secrets.AWS_DEFAULT_REGION}}',
+              'ruby-bundler-cache': '${{env.RUBY-BUNDLER-CACHE}}'
+            }
+          )
+        end
+      end
+
+      builder.build
+
+      setup = new_workflow.jobs[:go_unit_tests].steps.find { |step| step.name == 'Setup' }
+      expect(setup.with).not_to(have_key(:'aws-access-key-id'))
+      expect(setup.with).not_to(have_key(:'aws-secret-access-key'))
+      expect(setup.with).not_to(have_key(:'aws-region'))
+      expect(setup.with).to(include(:'ruby-bundler-cache')) # non-AWS inherited keys are preserved
+    end
+
     it 'sets up mongodb options when dependency file contains mongodb string' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       stub_config_file_reads(go_language_yaml)
       stub_go_language_detection


### PR DESCRIPTION
## Summary

`github-build`'s `language_job_builder.rb#build_setup_step` injected `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_DEFAULT_REGION` into the Setup step of every generated `<lang>_unit_tests` job. But those suites stub all AWS clients and never make a real AWS call, so the credentials are unused. Handing long-lived static keys to a job that runs `bundle install` + dozens of third-party gems is a least-privilege / blast-radius gap: a compromised test-time dependency could exfiltrate them (fork-PR builds don't receive secrets, so exposure is limited to same-repo builds). This stops the generator from doing that.

**Key changes:**

- **`lib/ghb/language_job_builder.rb`** — two parts in `build_setup_step`:
  - **(A)** Removed the `aws-*` entries from the `with.empty?` default block, so **newly generated** repos never get long-lived AWS keys in unit-test jobs.
  - **(B)** Added a strip step right after `copy_properties` (`%i[aws-access-key-id aws-secret-access-key aws-region].each { |key| with.delete(key) }`), so keys **inherited from a previously generated workflow** are removed on regeneration. Non-AWS inherited keys (`ssh-key`, `ruby-bundler-cache`, etc.) are preserved.
  - Scope is unit-test setup only — the deploy-oriented builders (`aws_job_builder`, `code_deploy_job_builder`, `vercel_job_builder`) that genuinely need credentials are untouched.
- **`spec/ghb/language_job_builder_spec.rb`** — two regression specs: the default Setup omits `aws-*`, and inherited `aws-*` are stripped while non-AWS keys survive. Both verified to fail before the fix.
- **`spec/fixtures/workflow_generation/build.yml`** — golden snapshot regenerated (`UPDATE_SNAPSHOTS=1`); only the three `ruby_unit_tests` AWS lines were removed.

**Effect:** regenerating any repo (`aws`, `ci-actions`, `compliance`, `github-build`, `ci-tools`) drops the AWS keys from its unit-test job. Jobs that truly need AWS should use OIDC (`aws-actions/configure-aws-credentials` with a role).

Upstream fix for Cloud-Officer/ci-tools#504.

Tests: `bundle exec rspec` 423 examples, 0 failures; RuboCop clean.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified