### PR TITLE
Drop AWS keys from setup steps, run security linters on all events, bump deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Semgrep
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - variables
-    if: "${{needs.variables.outputs.SKIP_LINTERS != '1' && github.event_name == 'pull_request'}}"
+    if: "${{needs.variables.outputs.SKIP_LINTERS != '1'}}"
     timeout-minutes: 30
     steps:
     - name: Trivy
@@ -180,9 +180,6 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
-        aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
-        aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
     - name: Bats Install
       shell: bash
       run: |-
@@ -215,9 +212,6 @@ jobs:
       uses: cloud-officer/ci-actions/setup@v2
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
-        aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
-        aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
-        aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
         github-token: "${{secrets.GH_PAT}}"
     - name: Bundler

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,9 +22,6 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
-        aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
-        aws-region: "${{secrets.AWS_DEFAULT_REGION}}"
         ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
     - name: Close Stale Dependency PRs
       shell: bash

--- a/.soup.json
+++ b/.soup.json
@@ -62,7 +62,7 @@
   "concurrent-ruby": {
     "language": "Ruby",
     "package": "concurrent-ruby",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "license": "MIT",
     "description": "Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more.",
     "website": "http://www.concurrent-ruby.com",
@@ -194,7 +194,7 @@
   "i18n": {
     "language": "Ruby",
     "package": "i18n",
-    "version": "1.14.8",
+    "version": "1.15.0",
     "license": "MIT",
     "description": "New wave Internationalization support for Ruby.",
     "website": "https://github.com/ruby-i18n/i18n",
@@ -470,7 +470,7 @@
   "rubocop": {
     "language": "Ruby",
     "package": "rubocop",
-    "version": "1.87.0",
+    "version": "1.88.0",
     "license": "MIT",
     "description": "RuboCop is a Ruby code style checking and code formatting tool.",
     "website": "https://rubocop.org/",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -35,7 +35,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.8)
+    i18n (1.15.0)
       concurrent-ruby (~> 1.0)
     json (2.19.9)
     language_server-protocol (3.17.0.5)
@@ -74,7 +74,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.87.0)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -339,7 +339,7 @@ python:
     - .python-version
   setup_options:
     - name: python-version
-      value: 3.14.5
+      value: 3.14.6
     - name: python-version-file
       value:
     - name: python-cache

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,9 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 **Private Methods:**
 
-- `args_from_file(file)`: Reads arguments from existing build file
+- `args_from_file(file)`: Reads arguments from existing build file, stripping any flags that no longer exist before replay
+- `strip_removed_flags(args, file)`: Drops `REMOVED_FLAGS` from persisted args (warning on stderr) so an old `build.yml` header self-heals on the next regeneration instead of aborting on `OptionParser::InvalidOption`
+- `removed_flag?(arg)`: Returns whether an argument matches a removed flag (bare or `flag=value` form)
 
 **Attributes:**
 
@@ -203,6 +205,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 **Constants:**
 
 - `EPHEMERAL_FLAGS`: One-shot flags (e.g. `--sync_required_status_checks`) that are stripped from `original_argv` so they are not persisted to the generated workflow header
+- `REMOVED_FLAGS`: Flags removed from the CLI (e.g. `--mono_repo`) that may still linger in a downstream repo's persisted `build.yml` header; stripped with a warning during replay so old headers self-heal
 
 ### GHB::Status
 

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -7,7 +7,7 @@
 | Ruby | ast | 2.4.3 | MIT | A library for working with Abstract Syntax Trees. | <https://whitequark.github.io/ast/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | base64 | 0.3.0 | Ruby | Support for encoding and decoding binary data using a Base64 representation. | <https://github.com/ruby/base64> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | bigdecimal | 4.1.2 | Ruby | This library provides arbitrary-precision decimal floating-point number class. | <https://github.com/ruby/bigdecimal> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | concurrent-ruby | 1.3.6 | MIT | Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. | <http://www.concurrent-ruby.com> | 2026-05-22 | Low | Dependency | Dependency |
+| Ruby | concurrent-ruby | 1.3.7 | MIT | Modern concurrency tools including agents, futures, promises, thread pools, actors, supervisors, and more. | <http://www.concurrent-ruby.com> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | connection_pool | 3.0.2 | MIT | Generic connection pool for Ruby | <https://github.com/mperham/connection_pool> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | crack | 1.0.1 | MIT | Really simple JSON and XML parsing, ripped from Merb and Rails. | <https://github.com/jnunemaker/crack> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | csv | 3.3.5 | Ruby | The CSV library provides a complete interface to CSV files and data | <https://github.com/ruby/csv> | 2026-05-22 | Low | Dependency | Dependency |
@@ -18,7 +18,7 @@
 | Ruby | duplicate | 1.1.1 | Apache License Version 2.0 | Originally extracted from rack-app project | <http://www.rack-app.com> | 2026-05-22 | Low | Handle deep clone | Lightweight deep cloning library with no additional dependencies |
 | Ruby | hashdiff | 1.2.1 | MIT | Hashdiff is a diff lib to compute the smallest difference between two hashes | <https://github.com/liufengyun/hashdiff> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | httparty | 0.24.2 | MIT | Makes http fun! Also, makes consuming restful web services dead easy. | <https://github.com/jnunemaker/httparty> | 2026-05-22 | High | HTTP client for GitHub REST API communication | Industry-standard Ruby HTTP client with active maintenance and security updates |
-| Ruby | i18n | 1.14.8 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
+| Ruby | i18n | 1.15.0 | MIT | New wave Internationalization support for Ruby. | <https://github.com/ruby-i18n/i18n> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | json | 2.19.9 | Ruby | This is a JSON implementation as a Ruby extension in C. | <https://github.com/ruby/json> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | language_server-protocol | 3.17.0.5 | MIT | A Language Server Protocol SDK | <https://github.com/mtsmfm/language_server-protocol-ruby> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | lint_roller | 1.1.0 | MIT | A plugin specification for linter and formatter rulesets | <https://github.com/standardrb/lint_roller> | 2026-05-22 | Low | Dependency | Dependency |
@@ -41,7 +41,7 @@
 | Ruby | rspec-expectations | 3.13.5 | MIT | rspec-expectations provides a simple, readable API to express expected outcomes of a code example. | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-mocks | 3.13.8 | MIT | RSpec's 'test double' framework, with support for stubbing and mocking | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rspec-support | 3.13.7 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | rubocop | 1.87.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
+| Ruby | rubocop | 1.88.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
 | Ruby | rubocop-ast | 1.49.1 | MIT | RuboCop's Node and NodePattern classes. | <https://www.rubocop.org/> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rubocop-capybara | 2.23.0 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-graphql | 1.6.0 | MIT | A collection of RuboCop cops to improve GraphQL-related code | <https://github.com/DmitryTsepelev/rubocop-graphql> | 2026-05-22 | Low | Ruby linter | Most popular gem |


### PR DESCRIPTION
## Summary

This update tightens the security posture of the generated GitHub Actions workflows and refreshes pinned dependencies. The setup steps no longer inject long-lived AWS credentials, security linters now run on every event instead of pull requests only, and the documented self-healing flag-stripping behavior is reflected in the architecture notes.

**Key changes:**

- Remove `aws-access-key-id`, `aws-secret-access-key`, and `aws-region` inputs from the `cloud-officer/ci-actions/setup` steps in `build.yml` (two jobs) and `dependencies.yml`, so generated workflows stop pulling long-lived AWS keys where they are not needed.
- Run the Semgrep and Trivy security linters on all events by dropping the `github.event_name == 'pull_request'` guard in `build.yml`.
- Bump the Python `setup_options` default in `config/languages.yaml` from `3.14.5` to `3.14.6`.
- Refresh `Gemfile.lock`: `concurrent-ruby` 1.3.6→1.3.7, `i18n` 1.14.8→1.15.0, `rubocop` 1.87.0→1.88.0.
- Document the `strip_removed_flags`, `removed_flag?`, and `REMOVED_FLAGS` self-healing replay behavior in `docs/architecture.md`.
- Update SOUP files (`.soup.json`, `docs/soup.md`) to match the refreshed dependencies.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: changes are limited to workflow YAML, dependency pins, and documentation; no new code paths to cover
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified