### PR TITLE
Exclude nested Swift build caches from SwiftLint, skip trivy.yaml in cfnlint

### DIFF
--- a/config/linters/.cfnlintrc
+++ b/config/linters/.cfnlintrc
@@ -3,6 +3,7 @@ templates:
 ignore_templates:
   - .github/**
   - docs/**
+  - trivy.yaml
   # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
   - .build/**
   - .bundle/**

--- a/config/linters/.swiftlint.yml
+++ b/config/linters/.swiftlint.yml
@@ -5,38 +5,40 @@ excluded:
   - Frameworks
   - Package.swift
   - Project.swift
-  - SourcePackages
   - Tests
-  - Tuist/.build
-  - Tuist/Cache
-  - Tuist/Dependencies
   - fastlane
+  # Build/dependency caches can appear nested under submodule dirs
+  # (e.g. Projects/<sub>/Tuist/.build), so match them at any depth.
+  - "**/SourcePackages"
+  - "**/Tuist/.build"
+  - "**/Tuist/Cache"
+  - "**/Tuist/Dependencies"
   # ghb:excluded-dirs:start - managed by github-build from config/languages.yaml; do not edit by hand
-  - .build
-  - .bundle
-  - .git
-  - .gradle
-  - .hg
-  - .m2
-  - .npm
-  - .pnpm
-  - .pytest_cache
-  - .svn
-  - .venv
-  - .yarn
-  - __pycache__
-  - build
-  - Carthage
-  - coverage
-  - DerivedData
-  - dist
-  - env
-  - Libraries
-  - node_modules
-  - Pods
-  - target
-  - vendor
-  - venv
+  - "**/.build"
+  - "**/.bundle"
+  - "**/.git"
+  - "**/.gradle"
+  - "**/.hg"
+  - "**/.m2"
+  - "**/.npm"
+  - "**/.pnpm"
+  - "**/.pytest_cache"
+  - "**/.svn"
+  - "**/.venv"
+  - "**/.yarn"
+  - "**/__pycache__"
+  - "**/build"
+  - "**/Carthage"
+  - "**/coverage"
+  - "**/DerivedData"
+  - "**/dist"
+  - "**/env"
+  - "**/Libraries"
+  - "**/node_modules"
+  - "**/Pods"
+  - "**/target"
+  - "**/vendor"
+  - "**/venv"
   # ghb:excluded-dirs:end
 disabled_rules:
   - comment_spacing

--- a/lib/ghb/linter_ignore_renderer.rb
+++ b/lib/ghb/linter_ignore_renderer.rb
@@ -142,7 +142,13 @@ module GHB
     # shared dirs; Swift-specific extras (e.g. SourcePackages, Tuist/.build) live
     # outside the sentinels in the shipped template.
     def body_swiftlint(dirs)
-      lines = dirs.map { |dir| "  - #{dir}" }
+      # Match each excluded dir at ANY depth, mirroring the recursive globs the
+      # other renderers use (trivy `**/<dir>`, cfnlint `<dir>/**`, etc.). A bare
+      # `- .build` only excludes the repo-root copy, so nested build/checkout
+      # caches in submodules (e.g. Projects/<sub>/Tuist/.build/checkouts) slip
+      # through and trip `swiftlint --strict`. The leading `*` makes the scalar
+      # a YAML alias, so each entry is quoted.
+      lines = dirs.map { |dir| %(  - "**/#{dir}") }
       lines.join("\n")
     end
 

--- a/spec/ghb/linter_ignore_renderer_spec.rb
+++ b/spec/ghb/linter_ignore_renderer_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe(GHB::LinterIgnoreRenderer) do
       expect(result).to(include("  - .git/**\n  - Build/**\n  - coverage/**\n  - node_modules/**\n  - vendor/**"))
     end
 
-    it 'renders the swiftlint excluded block as indented list items, preserving Swift-specific extras' do
+    it 'renders the swiftlint excluded block as quoted anywhere-globs, preserving Swift-specific extras' do
       content = "excluded:\n  - SourcePackages\n  # ghb:excluded-dirs:start\n  - old\n  # ghb:excluded-dirs:end\n"
 
       result = renderer.render_excluded_dirs('.swiftlint.yml', content, dirs)
 
-      expect(result).to(include("  - SourcePackages\n  # ghb:excluded-dirs:start\n  - .git\n  - Build\n  - coverage\n  - node_modules\n  - vendor"))
+      expect(result).to(include(%(  - SourcePackages\n  # ghb:excluded-dirs:start\n  - "**/.git"\n  - "**/Build"\n  - "**/coverage"\n  - "**/node_modules"\n  - "**/vendor")))
     end
 
     it 'renders the trivy skip-dirs block as quoted, indented anywhere-globs, preserving project entries' do # rubocop:disable RSpec/MultipleExpectations


### PR DESCRIPTION
## Summary

Build and dependency caches can appear nested under submodule directories (e.g. `Projects/<sub>/Tuist/.build/checkouts`), so a bare `- .build` exclusion only covered the repo-root copy and let nested caches slip through and trip `swiftlint --strict`. This change makes the SwiftLint exclusions match at any depth, mirroring the recursive globs already used by the trivy and cfnlint renderers. It also ignores the generated `trivy.yaml` in cfnlint so it is not linted as a CloudFormation template.

**Key changes:**

- `lib/ghb/linter_ignore_renderer.rb`: render each SwiftLint excluded dir as a recursive `"**/<dir>"` glob (quoted, since the leading `*` would otherwise be a YAML alias), so nested build/checkout caches in submodules are excluded.
- `config/linters/.swiftlint.yml`: convert the managed excluded-dirs block and the Swift-specific build caches (`SourcePackages`, `Tuist/.build`, `Tuist/Cache`, `Tuist/Dependencies`) to `**/`-prefixed globs so they match at any depth.
- `config/linters/.cfnlintrc`: add `trivy.yaml` to `ignore_templates` so the generated Trivy config is not linted as a CFN template.
- `spec/ghb/linter_ignore_renderer_spec.rb`: update the SwiftLint renderer expectation to assert the new quoted anywhere-glob format.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
