### PR TITLE
Update architecture docs for SwiftLint excluded glob matching at any depth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `manages?(config_name)`: Returns whether a given linter config has a managed excluded-dirs block
 - `merges_existing?(config_name)`: Returns whether a config must be merged into the project's existing file (preserving content outside the managed block) rather than copied fresh from the bundled template
 - `managed_block?(content)`: Returns whether `content` carries a complete sentinel-delimited managed block
-- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns` — including the `ESLINT_EXTRA_IGNORES` globs, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries, gitignore-style lines for `.semgrepignore`, cfn-lint `ignore_templates` globs, SwiftLint `excluded` list items, Trivy `scan.skip-dirs` quoted `**/<dir>` globs), or returns `content` unchanged when unmanaged or missing sentinels
+- `render_excluded_dirs(config_name, content, dirs)`: Replaces the sentinel-delimited block in `content` with `dirs` rendered for the target config's native syntax (ESLint `ignorePatterns` — including the `ESLINT_EXTRA_IGNORES` globs, flake8 `extend-exclude`, Bandit `exclude`, yamllint ignore lines, PMD `exclude-pattern` entries, gitignore-style lines for `.semgrepignore`, cfn-lint `ignore_templates` globs, SwiftLint `excluded` quoted `**/<dir>` globs matched at any depth, Trivy `scan.skip-dirs` quoted `**/<dir>` globs), or returns `content` unchanged when unmanaged or missing sentinels
 
 ### GHB::GitHubAPIClient
 


### PR DESCRIPTION
## Summary

Updates `docs/architecture.md` to reflect the recent change to how SwiftLint excluded directories are rendered. The `render_excluded_dirs` description previously described SwiftLint's output as a plain `excluded` list; it now documents that SwiftLint entries are emitted as quoted `**/<dir>` globs matched at any depth, consistent with the actual rendering behavior.

**Key changes:**

- Update the `render_excluded_dirs(config_name, content, dirs)` entry in `docs/architecture.md` so the SwiftLint syntax description reads "quoted `**/<dir>` globs matched at any depth" instead of "`excluded` list items"

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change, no code behavior affected
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified