### PR TITLE
Bump external action references

### DIFF
--- a/config/actions.yaml
+++ b/config/actions.yaml
@@ -5,5 +5,5 @@
 # .github/workflows/external-actions-bump.yml cron bumps these entries (via
 # bump-actions/bump-actions.sh) to the latest upstream major, opening a PR for
 # review. cloud-officer/* actions are versioned separately (see CI_ACTIONS_VERSION).
-actions/checkout: v6
+actions/checkout: v7
 peter-evans/create-pull-request: v8


### PR DESCRIPTION
## Automated external action bumps

Bumps external GitHub Action versions in `config/actions.yaml` to their latest
upstream major/release. Generated by `bump-actions/bump-actions.sh` (issue #408).
Review the linked release notes for breaking changes before merging.

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v6 | v7 |

### Upstream release notes

#### actions/checkout v7

_Release notes not available; see https://github.com/actions/checkout/releases_
