### PR TITLE
Reduce generator output noise while keeping main steps

### DIFF
--- a/lib/ghb/linter_job_builder.rb
+++ b/lib/ghb/linter_job_builder.rb
@@ -77,14 +77,7 @@ module GHB
         return
       end
 
-      result = matches.join("\n")
-
       puts("        Enabling #{linter[:short_name]}...")
-      puts('            Found:')
-
-      result.each_line.map(&:strip).first(5).each do |line|
-        puts("              #{line}")
-      end
 
       copy_linter_config(linter, script_path)
       add_linter_job(short_name, linter)

--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -280,15 +280,7 @@ module GHB
         }
       }
 
-      response = github_client.patch(repo_url, body: security_settings, expected_codes: nil)
-
-      return unless response.code == 200
-
-      puts('        Secret scanning disabled')
-      puts('        Secret scanning push protection disabled')
-      puts('        Secret scanning validity checks disabled')
-      puts('        Secret scanning non-provider patterns disabled')
-      puts('        Secret scanning AI detection disabled')
+      github_client.patch(repo_url, body: security_settings, expected_codes: nil)
     end
 
     def enable_security_features(github_client, repo_url)
@@ -304,12 +296,6 @@ module GHB
       }
 
       github_client.patch(repo_url, body: security_settings)
-
-      puts('        Secret scanning enabled')
-      puts('        Secret scanning push protection enabled')
-      puts('        Secret scanning validity checks enabled')
-      puts('        Secret scanning non-provider patterns enabled')
-      puts('        Secret scanning AI detection (generic passwords) enabled')
     end
 
     def disable_codeql_default_setup(github_client, repo_url)
@@ -318,38 +304,32 @@ module GHB
         state: 'not-configured'
       }
 
-      response = github_client.patch(
+      github_client.patch(
         "#{repo_url}/code-scanning/default-setup",
         body: code_scanning_config,
         expected_codes: nil
       )
-
-      puts('        CodeQL default setup disabled') if [200, 202].include?(response.code)
     end
 
     def enable_codeql_default_setup(github_client, repo_url)
       puts('    Enabling CodeQL default setup...')
 
-      # First check current status
+      # First check current status; skip the patch if it is already configured.
       response = github_client.get("#{repo_url}/code-scanning/default-setup")
       current_setup = JSON.parse(response.body)
 
-      if current_setup['state'] == 'configured'
-        puts('        CodeQL default setup already configured')
-      else
-        code_scanning_config = {
-          state: 'configured',
-          query_suite: 'default'
-        }
+      return if current_setup['state'] == 'configured'
 
-        github_client.patch(
-          "#{repo_url}/code-scanning/default-setup",
-          body: code_scanning_config,
-          expected_codes: [200, 202]
-        )
+      code_scanning_config = {
+        state: 'configured',
+        query_suite: 'default'
+      }
 
-        puts('        CodeQL default setup enabled')
-      end
+      github_client.patch(
+        "#{repo_url}/code-scanning/default-setup",
+        body: code_scanning_config,
+        expected_codes: [200, 202]
+      )
     end
   end
 end

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -1019,9 +1019,8 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
         allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil).and_return(codeql_disable_response))
       end
 
-      it 'prints CodeQL disabled confirmation for 202 response' do # rubocop:disable RSpec/MultipleExpectations
-        expect { configurator.configure }
-          .to(output(/CodeQL default setup disabled/).to_stdout)
+      it 'patches CodeQL default setup to not-configured for 202 response' do
+        configurator.configure
 
         expect(github_client).to(have_received(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil))
       end
@@ -1065,9 +1064,8 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
         allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil).and_return(codeql_disable_response))
       end
 
-      it 'does not print CodeQL disabled confirmation for non-200/202 response' do # rubocop:disable RSpec/MultipleExpectations
-        expect { configurator.configure }
-          .not_to(output(/CodeQL default setup disabled/).to_stdout)
+      it 'still patches CodeQL default setup for non-200/202 response' do
+        configurator.configure
 
         expect(github_client).to(have_received(:patch).with("#{repo_url}/code-scanning/default-setup", body: { state: 'not-configured' }, expected_codes: nil))
       end


### PR DESCRIPTION
## Summary

The build-file generator printed a confirmation line for every individual item it touched, which flooded the console and buried the actual progress steps. This trims the redundant per-item output while keeping every phase and main-step line, so a run still reads as a clear outline of what happened.

**Key changes:**

- Remove the five `Secret scanning ... disabled` / `... enabled` confirmation lines from `disable_security_features` / `enable_security_features`; the parent "Disabling/Enabling Advanced Security features..." step already says what is happening.
- Remove the CodeQL `default setup disabled` / `enabled` / `already configured` detail lines, keeping the parent "Disabling/Enabling CodeQL default setup..." step.
- Tidy the now-dead control flow this exposed: drop an unused `response` guard, collapse an empty `if` branch into a `return if ... 'configured'`, and remove the unused `result` variable.
- Drop the linter `Found:` block that listed matched files under each enabled linter.
- Update the two CodeQL specs to assert the patch call (the real behavior) instead of the removed stdout output.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified