### PR TITLE
Preserve AWS keys in unit-test setup and bump node/xcode versions

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -93,7 +93,7 @@ js:
     - .nvmrc
   setup_options:
     - name: node-version
-      value: 26.3.1
+      value: 26.4.0
     - name: node-always-auth
       value:
     - name: node-version-file
@@ -315,7 +315,7 @@ proto:
     - name: go-architecture
       value:
     - name: xcode-version
-      value: 26.5
+      value: 26.6
   dependencies:
     - dependency_file: go.mod
       install_dirs:

--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -212,14 +212,6 @@ module GHB
         copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
         do_uses("cloud-officer/ci-actions/setup@#{CI_ACTIONS_VERSION}")
 
-        # Unit-test suites stub all AWS clients and never call AWS, so the test job
-        # must not receive long-lived AWS access keys (least privilege: handing static
-        # credentials to a job that runs dozens of third-party gems widens the blast
-        # radius of a supply-chain compromise). Strip any inherited from a previously
-        # generated workflow, and never add them to the default block below. Jobs that
-        # genuinely need AWS should use OIDC. See Cloud-Officer/ci-tools#504.
-        %i[aws-access-key-id aws-secret-access-key aws-region].each { |key| with.delete(key) }
-
         # Remove version parameter from with if version file exists (version file takes precedence)
         if version_file
           version_option_key = (version_file == '.nvmrc' ? 'node-version' : version_file.delete_prefix('.')).to_sym

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       expect(setup.with).to(include(:'ssh-key', :'github-token'))
     end
 
-    it 'strips AWS keys inherited from a previously generated unit-test Setup step', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
+    it 'preserves AWS keys inherited from a previously generated unit-test Setup step', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       stub_config_file_reads(go_language_yaml)
       stub_go_language_detection
 
@@ -159,10 +159,8 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       builder.build
 
       setup = new_workflow.jobs[:go_unit_tests].steps.find { |step| step.name == 'Setup' }
-      expect(setup.with).not_to(have_key(:'aws-access-key-id'))
-      expect(setup.with).not_to(have_key(:'aws-secret-access-key'))
-      expect(setup.with).not_to(have_key(:'aws-region'))
-      expect(setup.with).to(include(:'ruby-bundler-cache')) # non-AWS inherited keys are preserved
+      expect(setup.with).to(include(:'aws-access-key-id', :'aws-secret-access-key', :'aws-region'))
+      expect(setup.with).to(include(:'ruby-bundler-cache'))
     end
 
     it 'sets up mongodb options when dependency file contains mongodb string' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations


### PR DESCRIPTION
## Summary

This change updates pinned toolchain versions and removes the logic that
stripped AWS credentials from generated unit-test `Setup` steps. Previously the
builder deleted `aws-access-key-id`, `aws-secret-access-key`, and `aws-region`
from any inherited unit-test Setup step (least-privilege for jobs that stub all
AWS calls). That stripping is now removed, so AWS keys inherited from a
previously generated workflow are preserved and passed through to the unit-test
job.

**Key changes:**

- `config/languages.yaml`: bump `node-version` from `26.3.1` to `26.4.0` and `xcode-version` from `26.5` to `26.6`.
- `lib/ghb/language_job_builder.rb`: remove the block that stripped `aws-access-key-id`/`aws-secret-access-key`/`aws-region` from inherited unit-test Setup steps.
- `spec/ghb/language_job_builder_spec.rb`: update the corresponding example to assert AWS keys are now preserved (rather than stripped) while non-AWS inherited keys remain.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): Reverts least-privilege AWS-key stripping in generated unit-test Setup steps

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

This reverts a deliberate least-privilege control (see Cloud-Officer/ci-tools#504): generated unit-test jobs run dozens of third-party gems, and passing long-lived static AWS credentials to them widens the blast radius of a supply-chain compromise. With this change, AWS keys inherited from a previously generated workflow are again forwarded to unit-test Setup steps. Reviewers should confirm this credential-exposure trade-off is intended before merging.
