### PR TITLE
Add --write-locks to Kotlin Gradle dependency update command

### DIFF
--- a/config/languages.yaml
+++ b/config/languages.yaml
@@ -229,7 +229,7 @@ kotlin:
       elasticsearch_dependency: elasticsearch
       package_manager_name: Gradle
       package_manager_default: gradle build
-      package_manager_update: gradle dependencies --refresh-dependencies
+      package_manager_update: gradle dependencies --refresh-dependencies --write-locks
       dependabot_ecosystem: gradle
     - dependency_file: pom.xml
       install_dirs:


### PR DESCRIPTION
## Summary

This change updates the Kotlin language configuration so the Gradle dependency update command also regenerates the dependency lockfiles. Previously `gradle dependencies --refresh-dependencies` refreshed the resolved dependencies but did not rewrite the lockfiles, leaving them stale after an update run. Adding `--write-locks` ensures the lockfiles are kept in sync.

**Key changes:**

- Append `--write-locks` to the Kotlin `package_manager_update` command in `config/languages.yaml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Single-line configuration value change covered by existing config tests
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified