### PR TITLE
Update Redis version option to latest

### DIFF
--- a/config/options/redis.yaml
+++ b/config/options/redis.yaml
@@ -11,7 +11,7 @@
 options:
   # Redis server version
   - name: redis-version
-    value: 9.0
+    value: latest
   # Port number (default: 6379)
   - name: redis-port
     value:


### PR DESCRIPTION
## Summary

Updates the default Redis server version option from a pinned `9.0` to `latest` so the generated configuration tracks the most recent Redis release rather than a fixed version.

**Key changes:**

- Set `redis-version` option `value` to `latest` in `config/options/redis.yaml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration value change only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified