### PR TITLE
Document branch protection, scanner exclusion, and flag persistence behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ To change the persisted arguments, either:
 * Run `github-build` again with the new set of flags, or
 * Edit the `# github-build ...` comment at the top of the build file directly
 
+One-shot flags are never persisted: `--sync_required_status_checks` is stripped from the saved comment so it only
+applies to the run where it is passed. Flags that no longer exist in the CLI but still linger in a saved header are
+dropped with a warning on the next run, so old headers self-heal instead of failing.
+
 ### Configuration Files
 
 `github-build` ships sensible defaults under `config/`. Each file can be overridden with a CLI flag pointing at your
@@ -211,7 +215,7 @@ root. No CLI flags are needed for these; they are detected on every run.
 | `appspec.yml` | Adds CodeDeploy and environment deployment jobs (`beta_deploy`, `rc_deploy`, `prod_deploy`) | Remove `appspec.yml` |
 | `vercel.json` (or a `"vercel"`/`"next"` dependency in `package.json`) | Adds Vercel deployment jobs (`beta_deploy`, `rc_deploy`, `prod_deploy`) driving the Vercel CLI. Ignored when `appspec.yml` is present (CodeDeploy wins). Custom steps such as `vercel alias` are preserved across regenerations | Remove `vercel.json` and the `vercel`/`next` dependency |
 | `.dockerhub` | Generates a separate Docker Hub workflow (`.github/workflows/docker.yml`) that pushes images on tag events | Remove the `.dockerhub` file |
-| `ci_scripts/` | Adds `Xcode` to the expected branch protection status checks | Remove the `ci_scripts/` directory |
+| `ci_scripts/` | Adds `Xcode` to the expected branch protection status checks and, for Swift projects, drops the `Swift Unit Tests` job since Xcode Cloud runs the tests (dependency information is still collected) | Remove the `ci_scripts/` directory |
 
 ### Required Secrets
 
@@ -227,7 +231,9 @@ Generated workflows reference the following GitHub Actions secrets that must be 
 
 #### AWS Secrets (CodeDeploy and Custom AWS Deployments)
 
-Required when using CodeDeploy (`--application_name`) or custom AWS deployments (`.aws` file present).
+Required when using CodeDeploy (`--application_name`) or custom AWS deployments (`.aws` file present). The generated
+Vercel deployment jobs also forward these credentials to the shared setup step, so they appear in Vercel-only
+repositories as well.
 
 | Secret                  | Purpose                                                                                            |
 |-------------------------|----------------------------------------------------------------------------------------------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -262,7 +262,8 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 - `cached_file_read(path)`: Caches and returns file contents to avoid redundant reads across builders
 - `excluded_dirs_from_config`: Builds the list of excluded directory patterns from `languages.yaml` by combining `install_dirs` from all dependency entries with the top-level `excluded_dirs`, memoized per instance
-- `find_files_matching(path, pattern, excluded_paths, max_depth:)`: Recursively searches for files matching a regex pattern using `Find.find`, with optional depth limit, explicit path exclusions, config-driven directory exclusions via `excluded_dirs_from_config`, and gitignored-path exclusions via `git_ignored?`
+- `excluded_paths_pattern(excluded_paths)`: Builds a single `Regexp.union` of the caller-supplied exclusion fragments and the `/<dir>/` forms of `excluded_dirs_from_config`, so each scanned path is tested once instead of once per fragment. Fragments are escaped, mirroring the literal `String#include?` semantics they replaced
+- `find_files_matching(path, pattern, excluded_paths, max_depth:)`: Recursively searches for files matching a regex pattern using `Find.find`, with optional depth limit, a single-pass exclusion test via `excluded_paths_pattern`, and gitignored-path exclusions via `git_ignored?`
 - `git_ignored?(file_path)`: Returns whether a path is ignored by the repo's `.gitignore` (and global/exclude rules), matched relative to the repo root
 - `gitignored_paths`: Computes the git-ignored files and directories once via `git ls-files --others --ignored --exclude-standard --directory` (so real `.gitignore` semantics apply); returns `[]` when git is unavailable or the cwd is not a repository, leaving scanning unfiltered
 - `file_contains?(file, pattern)`: Checks if a file contains a literal string match using `File.foreach`
@@ -513,9 +514,13 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 **Private Methods:**
 
-- `configure_branch_protection(github_client, repo_url, current_protection, protection_exists)`: Builds and applies the branch protection payload
-- `augment_required_status_checks`: Adds integration-derived checks (Vercel, CodeQL) to the collected list
-- `validate_required_checks!(expected_checks, actual_checks, protection_exists)`: Raises on a check mismatch unless `--sync_required_status_checks` is set
+- `configure_branch_protection(github_client, repo_url, current_protection, protection_exists)`: Assembles the expected check list (generated jobs, augmented checks, Xcode Cloud checks), validates it, applies the branch protection payload, and enables required signatures
+- `augment_required_status_checks`: Adds integration-derived checks to the collected list — a `Vercel` check when `package.json` declares `"next"`, plus the job names of a hand-maintained `.github/workflows/smoke.yml` (read dynamically, since that workflow is intentionally not generated). CodeQL checks are deliberately excluded: default setup runs in "smart mode" and only on relevant file changes, so it blocks PRs through code scanning alerts rather than a required check
+- `log_codeql_languages(github_client, repo_url)`: Reports the languages CodeQL default setup covers (filtering the redundant `javascript-typescript` / `typescript` entries the API returns alongside `javascript`); informational only — it contributes no required checks
+- `discover_xcode_cloud_checks(github_client, repo_url, actual_checks, expected_checks, protection_exists)`: Returns Xcode Cloud checks when a `ci_scripts` directory exists, dispatching to the protection-based or commit-status-based discovery below
+- `required_checks_differ?(expected_checks, actual_checks)`: Returns whether the two check lists differ in either direction
+- `validate_required_checks!(expected_checks, actual_checks, protection_exists)`: Prints the missing/extra checks and raises on a mismatch unless `--sync_required_status_checks` is set
+- `build_branch_protection_payload(current_protection, expected_checks, protection_exists, sync_required_status_checks)`: Builds the PUT body — reusing the remote check list unless syncing, preserving `app_id` values when syncing, and `filter_map`-ing dismissal/bypass users and teams so the payload never carries a `[null]` array (which GitHub rejects with 422)
 - `discover_xcode_cloud_checks_from_protection(actual_checks, expected_checks)`: Extracts Xcode Cloud checks from existing branch protection by finding checks not in the expected set
 - `discover_xcode_cloud_checks_from_statuses(github_client, repo_url)`: Discovers Xcode Cloud checks from commit statuses on the default branch for new repos without existing protection
 - `configure_repository_options(github_client, repo_url)`: Applies merge strategy, wiki/projects, and delete-branch-on-merge settings
@@ -694,15 +699,14 @@ All dependencies are managed via Bundler with versions locked in `Gemfile.lock`.
 1. Validates `GITHUB_TOKEN` environment variable is present
 2. Retrieves current repository info to check visibility (public/private) via `GitHubAPIClient`
 3. Gets current branch protection via GitHub API (handles 404 for new repos without protection)
-4. Detects Vercel integration (Next.js) and CodeQL languages, filtering redundant entries
+4. Augments the checks collected from generated workflow jobs with a `Vercel` check (when `package.json` declares `"next"`) and the job names of a hand-maintained `.github/workflows/smoke.yml`. CodeQL languages are logged for visibility only — CodeQL default setup runs in "smart mode" and is intentionally not made a required check
 5. Discovers Xcode Cloud checks dynamically when `ci_scripts` directory exists: extracts from existing branch protection or from commit statuses on the default branch for new repos
-6. Collects required status checks from generated workflow jobs
-7. Validates existing checks match expected checks (only for existing protection); on mismatch, raises an error unless `--sync_required_status_checks` is set, in which case the remote check list is rebuilt from `expected_checks` while preserving `app_id` values for existing entries (so integration-specific configurations such as Xcode Cloud checks are not clobbered)
-8. Preserves existing dismissal restrictions and bypass allowances
-9. Configures branch protection with required status checks, code-owner review enforcement (`require_code_owner_reviews: true`), pull request reviews, signed commits, and conversation resolution
-10. Configures repository options: enables vulnerability alerts and automated security fixes, disables wiki and projects, configures merge strategies, and enables delete branch on merge
-11. Enables secret scanning features (push protection, validity checks, non-provider patterns, AI detection) for public repos; disables them for private repos (GHAS cost avoidance)
-12. Enables CodeQL default setup for public repos; disables it for private repos (GHAS cost avoidance)
+6. Validates existing checks match expected checks (only for existing protection); on mismatch, raises an error unless `--sync_required_status_checks` is set, in which case the remote check list is rebuilt from `expected_checks` while preserving `app_id` values for existing entries (so integration-specific configurations such as Xcode Cloud checks are not clobbered)
+7. Builds the protection payload, preserving existing dismissal restrictions and bypass allowances while dropping entries GitHub returns without a `login`/`slug` so the request body never contains a `[null]` users/teams array
+8. Configures branch protection with required status checks, code-owner review enforcement (`require_code_owner_reviews: true`), pull request reviews, and conversation resolution, then enables required signatures via the separate `required_signatures` endpoint
+9. Configures repository options: enables vulnerability alerts and automated security fixes, disables wiki and projects, configures merge strategies, and enables delete branch on merge
+10. Enables secret scanning features (push protection, validity checks, non-provider patterns, AI detection) for public repos; disables them for private repos (GHAS cost avoidance)
+11. Enables CodeQL default setup for public repos; disables it for private repos (GHAS cost avoidance)
 
 **Security Considerations:**
 


### PR DESCRIPTION
# Summary

Brings `README.md` and `docs/architecture.md` back in line with the current
behavior of the CLI. No code changes — this documents behavior that already
ships, covering saved-header flag handling, the Swift/Xcode Cloud interaction,
AWS secrets in Vercel-only repos, the single-pass scanner exclusion helper, and
the reworked branch protection flow.

**Key changes:**

- `README.md`: document that `--sync_required_status_checks` is a one-shot flag stripped from the persisted `# github-build ...` header, and that unknown flags in an old header are dropped with a warning so headers self-heal
- `README.md`: note that a `ci_scripts/` directory also drops the `Swift Unit Tests` job for Swift projects (Xcode Cloud runs the tests; dependency info is still collected)
- `README.md`: clarify that the AWS secrets are also forwarded by the generated Vercel deployment jobs, so they are required in Vercel-only repositories
- `docs/architecture.md`: document the `excluded_paths_pattern` helper and the single-pass exclusion test it gives `find_files_matching`
- `docs/architecture.md`: rewrite the branch protection private-method list — expanded `configure_branch_protection` and `augment_required_status_checks` (Vercel + `smoke.yml` job names, and why CodeQL is deliberately not a required check), plus the new `log_codeql_languages`, `discover_xcode_cloud_checks`, `required_checks_differ?`, and `build_branch_protection_payload` entries
- `docs/architecture.md`: renumber and correct the branch protection flow — CodeQL languages are logged only, the payload drops `login`/`slug`-less entries to avoid a `[null]` users/teams array (422), and required signatures are enabled through the separate endpoint

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change; no code paths affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
