### PR TITLE
#476: Adopt set -euo pipefail and consistent yq flag order in update_versions.sh

### DIFF
--- a/bin/update_versions.sh
+++ b/bin/update_versions.sh
@@ -1,103 +1,139 @@
 #!/usr/bin/env bash
-set -e
+
+# Refresh the pinned language and service versions in config/languages.yaml and
+# config/options/*.yaml from their upstream sources. Run from the repository
+# root (every path below is relative to the working directory).
+#
+# Strict mode note: each lookup is a `<fetch> | <filter>` pipeline whose filters
+# (jq, grep, sort, tail) exit 0 on empty input, so under bare `set -e` a failed
+# fetch used to write an empty version into the config YAML. Under `pipefail`
+# those pipelines fail instead, so every lookup ends with `|| true` — keeping
+# the AWS-first paths degrading to their public fallback — and every resolved
+# value is checked by `require_version` before yq touches a file.
+
+set -euo pipefail
 
 LANGUAGE_FILE="config/languages.yaml"
 
+# Abort with a clear error instead of writing an empty (or JSON null) version
+# into a config file.
+function require_version()
+{
+  local name="$1" value="$2"
+
+  if [ -z "${value}" ] || [ "${value}" == "null" ]; then
+    echo "::error::could not resolve the latest ${name} version" >&2
+    exit 1
+  fi
+}
+
 # Go
 
-latest=$(curl -s https://go.dev/VERSION?m=text)
+latest=$(curl -fsS "https://go.dev/VERSION?m=text" || true)
 latest_go=$(echo "${latest#go}" | awk 'NR==1 { print $1 }')
+require_version "Go" "${latest_go}"
 export latest_go
-yq --indent=2 e '(.go.setup_options[] | select(.name == "go-version").value) = env(latest_go)' -i "${LANGUAGE_FILE}"
-yq --indent=2 e '(.proto.setup_options[] | select(.name == "go-version").value) = env(latest_go)' -i "${LANGUAGE_FILE}"
+yq e --indent=2 '(.go.setup_options[] | select(.name == "go-version").value) = env(latest_go)' -i "${LANGUAGE_FILE}"
+yq e --indent=2 '(.proto.setup_options[] | select(.name == "go-version").value) = env(latest_go)' -i "${LANGUAGE_FILE}"
 
 # Node.js
 
-latest=$(curl -s https://nodejs.org/dist/index.json | jq -r '.[0].version')
+latest=$(curl -fsS "https://nodejs.org/dist/index.json" | jq -r '.[0].version' || true)
 latest_node=${latest#v}
+require_version "Node.js" "${latest_node}"
 export latest_node
 yq e --indent=2 '(.js.setup_options[] | select(.name == "node-version").value) = env(latest_node)' -i "${LANGUAGE_FILE}"
 
 # Java (track the latest LTS major, not a hardcoded interim release or exact patch)
 
-latest_java=$(curl -s "https://api.adoptium.net/v3/info/available_releases" | jq -r '.most_recent_lts')
+latest_java=$(curl -fsS "https://api.adoptium.net/v3/info/available_releases" | jq -r '.most_recent_lts' || true)
+require_version "Java" "${latest_java}"
 export latest_java
-yq e --indent=2 '(.kotlin.setup_options[] | select(.name == "java-version").value) = env(latest_java)' -i  "${LANGUAGE_FILE}"
+yq e --indent=2 '(.kotlin.setup_options[] | select(.name == "java-version").value) = env(latest_java)' -i "${LANGUAGE_FILE}"
 
 # PHP
 
-releases=$(curl -s "https://www.php.net/releases/index.php?json=1")
-latest_php=$(echo "${releases}" | jq -r 'to_entries | map(.value) | map(select(.version | test("^8\\."))) | map(.version)[]' | sort -V | tail -n1)
+releases=$(curl -fsS "https://www.php.net/releases/index.php?json=1" || true)
+latest_php=$(echo "${releases}" | jq -r 'to_entries | map(.value) | map(select(.version | test("^8\\."))) | map(.version)[]' | sort -V | tail -n1 || true)
+require_version "PHP" "${latest_php}"
 export latest_php
 yq e --indent=2 '(.php.setup_options[] | select(.name == "php-version").value) = env(latest_php)' -i "${LANGUAGE_FILE}"
 
 # Xcode
 
-releases=$(curl -s "https://xcodereleases.com/data.json")
-latest_xcode=$(echo "${releases}" |  jq -r '[.[] | select(.version.release.release == true) | .version][0].number')
+releases=$(curl -fsS "https://xcodereleases.com/data.json" || true)
+latest_xcode=$(echo "${releases}" | jq -r '[.[] | select(.version.release.release == true) | .version][0].number' || true)
+require_version "Xcode" "${latest_xcode}"
 export latest_xcode
 yq e --indent=2 '(.proto.setup_options[] | select(.name == "xcode-version").value) = env(latest_xcode)' -i "${LANGUAGE_FILE}"
 
 # Python
 
-latest_python=$(pyenv install --list | grep -oE '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^[[:space:]]*//' | sort -V | tail -n1)
+latest_python=$(pyenv install --list | grep -oE '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^[[:space:]]*//' | sort -V | tail -n1 || true)
+require_version "Python" "${latest_python}"
 export latest_python
-yq --indent=2 e '(.python.setup_options[] | select(.name == "python-version").value) = env(latest_python)' -i "${LANGUAGE_FILE}"
+yq e --indent=2 '(.python.setup_options[] | select(.name == "python-version").value) = env(latest_python)' -i "${LANGUAGE_FILE}"
 
 # Ruby
 
-latest_ruby=$(rbenv install -l | grep -E '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^[[:space:]]*//' | sort -V | tail -n1)
+latest_ruby=$(rbenv install -l | grep -E '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^[[:space:]]*//' | sort -V | tail -n1 || true)
+require_version "Ruby" "${latest_ruby}"
 export latest_ruby
-yq --indent=2 e '(.ruby.setup_options[] | select(.name == "ruby-version").value) = env(latest_ruby)' -i "${LANGUAGE_FILE}"
+yq e --indent=2 '(.ruby.setup_options[] | select(.name == "ruby-version").value) = env(latest_ruby)' -i "${LANGUAGE_FILE}"
 
 # MongoDB (DocumentDB)
 
-latest_mongodb=$(aws docdb describe-db-engine-versions --engine docdb --query 'DBEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1)
+latest_mongodb=$(aws docdb describe-db-engine-versions --engine docdb --query 'DBEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1 || true)
 
 if [ -z "${latest_mongodb}" ]; then
-    latest_mongodb=$(curl -s https://api.github.com/repos/mongodb/mongo/releases | jq -r '[.[] | select(.tag_name | test("^r[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name | ltrimstr("r")] | map(select(. | startswith("5.0") or startswith("4."))) | sort_by(. | split(".") | map(tonumber)) | last')
+    latest_mongodb=$(curl -fsS https://api.github.com/repos/mongodb/mongo/releases | jq -r '[.[] | select(.tag_name | test("^r[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name | ltrimstr("r")] | map(select(. | startswith("5.0") or startswith("4."))) | sort_by(. | split(".") | map(tonumber)) | last' || true)
 fi
 
+require_version "MongoDB" "${latest_mongodb}"
 export latest_mongodb
-yq --indent=2 e '(.options[] | select(.name == "mongodb-version").value) = env(latest_mongodb)' -i "config/options/mongodb.yaml"
+yq e --indent=2 '(.options[] | select(.name == "mongodb-version").value) = env(latest_mongodb)' -i "config/options/mongodb.yaml"
 
 # MySQL (Aurora)
 
-latest_mysql=$(aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1 | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+latest_mysql=$(aws rds describe-db-engine-versions --engine aurora-mysql --query 'DBEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1 | sed -E 's/^([0-9]+\.[0-9]+).*/\1/' || true)
 
 if [ -z "${latest_mysql}" ]; then
-    latest_mysql=$(curl -s https://dev.mysql.com/downloads/mysql/ | grep -oE 'MySQL Community Server [0-9]+\.[0-9]+\.[0-9]+' | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1)
+    latest_mysql=$(curl -fsS https://dev.mysql.com/downloads/mysql/ | grep -oE 'MySQL Community Server [0-9]+\.[0-9]+\.[0-9]+' | head -n1 | grep -oE '[0-9]+\.[0-9]+' | head -n1 || true)
 fi
 
+require_version "MySQL" "${latest_mysql}"
 export latest_mysql
-yq --indent=2 e '(.options[] | select(.name == "mysql-version").value) = env(latest_mysql)' -i "config/options/mysql.yaml"
+yq e --indent=2 '(.options[] | select(.name == "mysql-version").value) = env(latest_mysql)' -i "config/options/mysql.yaml"
 
 # Valkey (ElastiCache)
 
-latest_valkey=$(aws elasticache describe-cache-engine-versions --engine valkey --query 'CacheEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1)
+latest_valkey=$(aws elasticache describe-cache-engine-versions --engine valkey --query 'CacheEngineVersions[*].EngineVersion' --output text 2>/dev/null | tr '\t' '\n' | sort -V | tail -n1 || true)
 
 if [ -z "${latest_valkey}" ]; then
-    latest_valkey=$(curl -s https://api.github.com/repos/valkey-io/valkey/releases | jq -r '[.[] | select(.tag_name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first')
+    latest_valkey=$(curl -fsS https://api.github.com/repos/valkey-io/valkey/releases | jq -r '[.[] | select(.tag_name | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first' || true)
 fi
 
-# Validate version against actions-setup-redis supported valkey versions
-valkey_versions=$(curl -s https://raw.githubusercontent.com/shogo82148/actions-setup-redis/main/src/versions/valkey.json | jq -r '[.[].version | split(".")[0:2] | join(".")] | unique | .[]')
-valkey_minor=$(echo "${latest_valkey}" | grep -oE '^[0-9]+\.[0-9]+')
+# Validate version against actions-setup-redis supported valkey versions. An
+# unsupported or unresolved version degrades to the "latest" tag rather than
+# failing the run.
+valkey_versions=$(curl -fsS https://raw.githubusercontent.com/shogo82148/actions-setup-redis/main/src/versions/valkey.json | jq -r '[.[].version | split(".")[0:2] | join(".")] | unique | .[]' || true)
+valkey_minor=$(echo "${latest_valkey}" | grep -oE '^[0-9]+\.[0-9]+' || true)
 
-if [ -z "${latest_valkey}" ] || ! echo "${valkey_versions}" | grep -q "^${valkey_minor}$"; then
+if [ -z "${latest_valkey}" ] || [ -z "${valkey_minor}" ] || ! echo "${valkey_versions}" | grep -q "^${valkey_minor}$"; then
     latest_valkey="latest"
 fi
 
 export latest_valkey
-yq --indent=2 e '(.options[] | select(.name == "redis-version").value) = env(latest_valkey)' -i "config/options/redis.yaml"
+yq e --indent=2 '(.options[] | select(.name == "redis-version").value) = env(latest_valkey)' -i "config/options/redis.yaml"
 
 # Elasticsearch (OpenSearch)
 
-latest_elasticsearch=$(aws opensearch list-versions --query 'Versions[*]' --output text 2>/dev/null | tr '\t' '\n' | grep -E '^Elasticsearch_[0-9]+\.[0-9]+$' | sed 's/Elasticsearch_//' | sort -V | tail -n1)
+latest_elasticsearch=$(aws opensearch list-versions --query 'Versions[*]' --output text 2>/dev/null | tr '\t' '\n' | grep -E '^Elasticsearch_[0-9]+\.[0-9]+$' | sed 's/Elasticsearch_//' | sort -V | tail -n1 || true)
 
 if [ -z "${latest_elasticsearch}" ]; then
-    latest_elasticsearch=$(curl -s https://api.github.com/repos/elastic/elasticsearch/releases | jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name | ltrimstr("v")] | first')
+    latest_elasticsearch=$(curl -fsS https://api.github.com/repos/elastic/elasticsearch/releases | jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name | ltrimstr("v")] | first' || true)
 fi
 
+require_version "Elasticsearch" "${latest_elasticsearch}"
 export latest_elasticsearch
-yq --indent=2 e '(.options[] | select(.name == "elasticsearch-version").value) = env(latest_elasticsearch)' -i "config/options/elasticsearch.yaml"
+yq e --indent=2 '(.options[] | select(.name == "elasticsearch-version").value) = env(latest_elasticsearch)' -i "config/options/elasticsearch.yaml"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -621,7 +621,10 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - Fetches latest versions from official sources (go.dev, nodejs.org, etc.)
 - Updates `config/languages.yaml` with latest language versions
 - Updates `config/options/*.yaml` with latest service versions
-- Uses `yq` for YAML manipulation
+- Uses `yq` for YAML manipulation (always invoked as `yq e --indent=2 ... -i <file>`)
+- `require_version(name, value)`: Aborts with `::error::could not resolve the latest <name> version` when a lookup resolves to an empty or `null` value, so a failed upstream fetch can never write an empty version into a config file
+
+**Behavior:** Runs under `set -euo pipefail`; because the filter stages (`jq`, `grep`, `sort`, `tail`) exit 0 on empty input, each lookup pipeline ends with `|| true` and is validated by `require_version`. The AWS-first service lookups (DocumentDB, Aurora MySQL, ElastiCache Valkey, OpenSearch) still degrade to their public fallback when the AWS CLI is unavailable, and an unresolved or unsupported Valkey version degrades to the `latest` tag. Covered by `tests/update_versions.bats`, which stubs `curl`/`aws`/`pyenv`/`rbenv` and runs against a throwaway copy of `config/`.
 
 ### bump-actions/bump-actions.sh
 

--- a/tests/update_versions.bats
+++ b/tests/update_versions.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+
+# Tests for bin/update_versions.sh. Fake `curl`, `aws`, `pyenv` and `rbenv`
+# binaries on PATH resolve fixed upstream payloads (no network, no AWS
+# credentials), and the script runs against a throwaway copy of `config/` so the
+# real files are never touched. Real `jq`/`yq` are used so the actual filters and
+# yq expressions are exercised.
+#
+# Fake behaviour is driven by env knobs: FAKE_CURL_FAIL (substring of the URL to
+# fail on), FAKE_AWS_OK (AWS answers instead of failing), FAKE_JAVA_NULL,
+# FAKE_PYENV_EMPTY and FAKE_VALKEY_UNSUPPORTED.
+
+setup() {
+  command -v jq >/dev/null || skip "jq is not installed"
+  command -v yq >/dev/null || skip "yq is not installed"
+
+  SCRIPT="${BATS_TEST_DIRNAME}/../bin/update_versions.sh"
+  BIN="$(mktemp -d)"
+  WORK="$(mktemp -d)"
+  export PATH="${BIN}:${PATH}"
+  make_fakes
+  cp -R "${BATS_TEST_DIRNAME}/../config" "${WORK}/config"
+  cd "${WORK}" || exit 1
+}
+
+teardown() {
+  cd "${BATS_TEST_DIRNAME}" || exit 1
+  rm -rf "${BIN}" "${WORK}"
+}
+
+make_fakes() {
+  cat > "${BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+url=""
+for arg in "$@"; do
+  case "${arg}" in http*) url="${arg}" ;; esac
+done
+
+if [ -n "${FAKE_CURL_FAIL:-}" ] && [[ "${url}" == *"${FAKE_CURL_FAIL}"* ]]; then
+  echo "curl: (22) simulated upstream failure for ${url}" >&2
+  exit 22
+fi
+
+case "${url}" in
+  *go.dev/VERSION*)
+    printf 'go1.25.3\ntime 2026-01-01T00:00:00Z\n' ;;
+  *nodejs.org/dist/index.json*)
+    printf '[{"version":"v24.4.1"},{"version":"v24.4.0"}]\n' ;;
+  *api.adoptium.net*)
+    if [ -n "${FAKE_JAVA_NULL:-}" ]; then printf '{}\n'; else printf '{"most_recent_lts":21}\n'; fi ;;
+  *php.net/releases*)
+    printf '{"8.5":{"version":"8.5.1"},"8.4":{"version":"8.4.3"},"7.4":{"version":"7.4.33"}}\n' ;;
+  *xcodereleases.com*)
+    printf '[{"version":{"number":"26.2","release":{"beta":1}}},{"version":{"number":"26.1","release":{"release":true}}}]\n' ;;
+  *mongodb/mongo/releases*)
+    printf '[{"tag_name":"r8.0.4"},{"tag_name":"r5.0.31"},{"tag_name":"r4.4.29"}]\n' ;;
+  *dev.mysql.com*)
+    printf '<p>MySQL Community Server 9.2.0 (GA)</p>\n' ;;
+  *valkey-io/valkey/releases*)
+    if [ -n "${FAKE_VALKEY_UNSUPPORTED:-}" ]; then
+      printf '[{"tag_name":"9.9.9"}]\n'
+    else
+      printf '[{"tag_name":"8.1.1"},{"tag_name":"8.0.2"}]\n'
+    fi ;;
+  *actions-setup-redis*)
+    printf '[{"version":"8.1.0"},{"version":"7.2.5"}]\n' ;;
+  *elastic/elasticsearch/releases*)
+    printf '[{"tag_name":"v9.1.2"},{"tag_name":"v8.19.0"}]\n' ;;
+  *)
+    echo "unexpected url: ${url}" >&2; exit 1 ;;
+esac
+EOF
+
+  cat > "${BIN}/aws" <<'EOF'
+#!/usr/bin/env bash
+if [ -z "${FAKE_AWS_OK:-}" ]; then
+  echo "Unable to locate credentials." >&2
+  exit 255
+fi
+
+case "$1" in
+  docdb)       printf '5.0.0\t4.0.0\n' ;;
+  rds)         printf '8.0.mysql_aurora.3.05.2\t5.7.mysql_aurora.2.11.4\n' ;;
+  elasticache) printf '8.1.0\t7.2.6\n' ;;
+  opensearch)  printf 'Elasticsearch_7.10\tOpenSearch_2.13\tElasticsearch_8.1\n' ;;
+  *)           echo "unexpected aws command: $1" >&2; exit 1 ;;
+esac
+EOF
+
+  cat > "${BIN}/pyenv" <<'EOF'
+#!/usr/bin/env bash
+[ -n "${FAKE_PYENV_EMPTY:-}" ] && exit 0
+printf '  3.13.1\n  3.14.0\n  3.14.0rc1\n  anaconda3-2024.02\n'
+EOF
+
+  cat > "${BIN}/rbenv" <<'EOF'
+#!/usr/bin/env bash
+printf '  3.4.2\n  3.5.0\n  jruby-9.4.5.0\n'
+EOF
+
+  chmod +x "${BIN}/curl" "${BIN}/aws" "${BIN}/pyenv" "${BIN}/rbenv"
+}
+
+# Read an option value back out of a config file.
+value_of() {
+  yq e "(.${2}[] | select(.name == \"${3}\").value)" "${1}"
+}
+
+# ===========================================================================
+# Conventions (the finding this script was changed for)
+# ===========================================================================
+
+@test "the script runs under strict mode" {
+  grep -q '^set -euo pipefail$' "${BATS_TEST_DIRNAME}/../bin/update_versions.sh"
+  ! grep -qE '^set -e$' "${BATS_TEST_DIRNAME}/../bin/update_versions.sh"
+}
+
+@test "every yq invocation uses the same flag order" {
+  script="${BATS_TEST_DIRNAME}/../bin/update_versions.sh"
+  total="$(grep -cE '^yq ' "${script}")"
+  ordered="$(grep -cE '^yq e --indent=2 ' "${script}")"
+  [ "${total}" -gt 0 ]
+  [ "${total}" -eq "${ordered}" ]
+  ! grep -qE '^yq --indent' "${script}"
+}
+
+# ===========================================================================
+# Success path
+# ===========================================================================
+
+@test "resolves and writes every language and service version" {
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(value_of config/languages.yaml go.setup_options go-version)" = "1.25.3" ]
+  [ "$(value_of config/languages.yaml proto.setup_options go-version)" = "1.25.3" ]
+  [ "$(value_of config/languages.yaml js.setup_options node-version)" = "24.4.1" ]
+  [ "$(value_of config/languages.yaml kotlin.setup_options java-version)" = "21" ]
+  [ "$(value_of config/languages.yaml php.setup_options php-version)" = "8.5.1" ]
+  [ "$(value_of config/languages.yaml proto.setup_options xcode-version)" = "26.1" ]
+  [ "$(value_of config/languages.yaml python.setup_options python-version)" = "3.14.0" ]
+  [ "$(value_of config/languages.yaml ruby.setup_options ruby-version)" = "3.5.0" ]
+  [ "$(value_of config/options/mongodb.yaml options mongodb-version)" = "5.0.31" ]
+  [ "$(value_of config/options/mysql.yaml options mysql-version)" = "9.2" ]
+  [ "$(value_of config/options/redis.yaml options redis-version)" = "8.1.1" ]
+  [ "$(value_of config/options/elasticsearch.yaml options elasticsearch-version)" = "9.1.2" ]
+}
+
+@test "the rewritten config files stay valid two-space YAML" {
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  yq e '.' config/languages.yaml >/dev/null
+  grep -q '^  - name: mongodb-version$' config/options/mongodb.yaml
+}
+
+@test "AWS-sourced versions win over the public fallbacks when AWS answers" {
+  FAKE_AWS_OK=1 run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(value_of config/options/mongodb.yaml options mongodb-version)" = "5.0.0" ]
+  [ "$(value_of config/options/mysql.yaml options mysql-version)" = "8.0" ]
+  [ "$(value_of config/options/redis.yaml options redis-version)" = "8.1.0" ]
+  [ "$(value_of config/options/elasticsearch.yaml options elasticsearch-version)" = "8.1" ]
+}
+
+@test "a failing aws CLI falls back to the public sources instead of aborting" {
+  # Regression: under pipefail a non-zero `aws` would kill the whole pipeline
+  # before the `-z` fallback could run.
+  run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(value_of config/options/mongodb.yaml options mongodb-version)" = "5.0.31" ]
+  [ "$(value_of config/options/elasticsearch.yaml options elasticsearch-version)" = "9.1.2" ]
+}
+
+# ===========================================================================
+# Valkey / redis degradation
+# ===========================================================================
+
+@test "a valkey version unsupported by actions-setup-redis degrades to latest" {
+  FAKE_VALKEY_UNSUPPORTED=1 run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(value_of config/options/redis.yaml options redis-version)" = "latest" ]
+}
+
+@test "an unresolved valkey version degrades to latest instead of failing" {
+  FAKE_CURL_FAIL="valkey-io" run "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+  [ "$(value_of config/options/redis.yaml options redis-version)" = "latest" ]
+}
+
+# ===========================================================================
+# Failure paths — never write an empty version
+# ===========================================================================
+
+@test "a failed upstream fetch exits non-zero and writes nothing" {
+  before="$(cat config/languages.yaml)"
+  FAKE_CURL_FAIL="go.dev" run "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"could not resolve the latest Go version"* ]]
+  [ "$(cat config/languages.yaml)" = "${before}" ]
+}
+
+@test "a lookup whose filters yield nothing exits non-zero" {
+  # pyenv succeeds but grep/sort/tail produce no version.
+  FAKE_PYENV_EMPTY=1 run "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"could not resolve the latest Python version"* ]]
+  [ "$(value_of config/languages.yaml python.setup_options python-version)" != "" ]
+  [ "$(value_of config/languages.yaml python.setup_options python-version)" != "null" ]
+}
+
+@test "a JSON null answer is rejected like an empty one" {
+  FAKE_JAVA_NULL=1 run "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"could not resolve the latest Java version"* ]]
+  [ "$(value_of config/languages.yaml kotlin.setup_options java-version)" != "null" ]
+}
+
+@test "a service whose AWS and public lookups both fail exits non-zero" {
+  FAKE_CURL_FAIL="mongodb/mongo" run "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"could not resolve the latest MongoDB version"* ]]
+  [ "$(value_of config/options/mongodb.yaml options mongodb-version)" != "" ]
+}
+
+@test "every remaining lookup guards its own version" {
+  while read -r fail expected; do
+    FAKE_CURL_FAIL="${fail}" run "${SCRIPT}"
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"could not resolve the latest ${expected} version"* ]]
+  done <<'EOF'
+nodejs.org Node.js
+api.adoptium.net Java
+php.net PHP
+xcodereleases.com Xcode
+dev.mysql.com MySQL
+elastic/elasticsearch Elasticsearch
+EOF
+}
+
+@test "an unavailable lookup tool exits non-zero rather than blanking the version" {
+  printf '#!/usr/bin/env bash\necho "rbenv: command not found" >&2\nexit 127\n' > "${BIN}/rbenv"
+  chmod +x "${BIN}/rbenv"
+  run "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"could not resolve the latest Ruby version"* ]]
+}


### PR DESCRIPTION
## Summary

`bin/update_versions.sh` was the only shell script in the repo still running under bare `set -e`, and it mixed two `yq` flag orders. That was more than a style wart: every version lookup is a `<fetch> | <filter>` pipeline, and the filters (`jq`, `grep`, `sort`, `tail`) exit 0 on empty input — so a failed `curl` left the version variable empty and `yq` wrote an empty value straight into `config/languages.yaml` or `config/options/*.yaml` with no guard on the Go/Node/Java/PHP/Xcode paths.

This brings the script in line with the repo's conventions (`bump-actions.sh`, the embedded scripts in `auto_merge_manager.rb`, and the `run:` blocks in `auto-approve.yml` / `external-actions-bump.yml` all use `set -euo pipefail`) and makes a failed upstream lookup abort loudly instead of silently blanking a pinned version.

**Key changes:**

- `set -e` → `set -euo pipefail`, with a header comment explaining the pipefail implications for the lookup pipelines.
- Normalized all 12 `yq` invocations to a single `yq e --indent=2 ... -i <file>` order (the file previously mixed `yq --indent=2 e` and `yq e --indent=2`).
- Added a `require_version <name> <value>` helper that aborts with `::error::could not resolve the latest <name> version` when a lookup resolves empty or to the JSON string `null`, guarding every language and service path.
- Contained the regression `pipefail` would otherwise introduce: each lookup pipeline now ends with `|| true` and relies on the explicit guard, so the AWS-first lookups (DocumentDB, Aurora MySQL, ElastiCache Valkey, OpenSearch) still degrade to their public fallback when the AWS CLI is unavailable, and the Valkey "degrade to `latest`" path still works.
- `curl` calls now use `-fsS`, so an HTTP error body (rate-limited GitHub API, 404) is treated as a failure rather than parsed into an empty version.
- Added a `valkey_minor` empty check, so an unresolved Valkey version can no longer build a `grep -q "^$"` pattern that matches anything.
- New `tests/update_versions.bats` (14 tests) stubs `curl`/`aws`/`pyenv`/`rbenv` on `PATH` and runs the real script against a throwaway copy of `config/` with real `jq`/`yq`. It runs in CI via the existing `bats tests/` job.
- `docs/architecture.md`: documented the new helper, the strict-mode behavior, and the test file in the `bin/update_versions.sh` section.

No config values were changed — `config/` is untouched by the tests.

**Test evidence**

- `bats tests/` → `1..32`, all `ok`, 0 failures (18 pre-existing bump-actions + 14 new).
- Regression direction confirmed: with the pre-fix `bin/update_versions.sh` restored, 8 of the 14 new tests fail (strict mode, yq flag order, empty/null/failed-lookup guards, valkey degrade); all pass after.
- `bundle exec rspec` → `423 examples, 0 failures` (Ruby suite unaffected).
- `bundle exec rubocop` → `56 files inspected, no offenses detected`.
- `shellcheck bin/update_versions.sh` → clean (exit 0).

Closes #476

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
