### PR TITLE
Fix #474: expand matrix jobs into GitHub's real required status check names

### DIFF
--- a/lib/ghb/application.rb
+++ b/lib/ghb/application.rb
@@ -32,6 +32,10 @@ module GHB
   class Application
     include FileScanner
 
+    # Matrix keys that shape the expansion instead of declaring an axis.
+    MATRIX_CONTROL_KEYS = %i[include exclude].freeze
+    private_constant :MATRIX_CONTROL_KEYS
+
     def initialize(argv)
       @code_deploy_pre_steps = []
       @default_branch = detect_default_branch
@@ -254,16 +258,117 @@ module GHB
 
     def collect_required_status_checks
       @new_workflow.jobs.each_value do |job|
-        if job&.strategy&.[](:matrix)
-          job.strategy[:matrix].each_value do |values|
-            values.each do |value|
-              @required_status_checks << "#{job.name} (#{value})"
-            end
-          end
-        else
+        next if job.nil?
+
+        matrix = job.strategy.is_a?(Hash) ? job.strategy[:matrix] || job.strategy['matrix'] : nil
+
+        if matrix.nil?
           @required_status_checks << job.name
+          next
         end
+
+        combinations = matrix_combinations(matrix)
+
+        if combinations.nil?
+          warn("Warning: cannot expand the matrix of job '#{job.name}' into check names (dynamic or non-scalar matrix values); skipping it in the required status checks.")
+          next
+        end
+
+        combinations.each { |combination| @required_status_checks << "#{job.name} (#{combination.values.join(', ')})" }
       end
+    end
+
+    # Expands a job matrix into the combinations GitHub actually creates, in the
+    # same order, so the generated check names match the real check-run contexts
+    # (`Job (ubuntu-latest, 3.3)` rather than one name per axis value). `exclude:`
+    # combinations are dropped first, then `include:` rows are merged, mirroring
+    # GitHub's documented expansion (BUG-001, #474).
+    # @return [Array<Hash>, nil] the combinations, or nil when the matrix cannot be expanded statically
+    def matrix_combinations(matrix)
+      return unless matrix.is_a?(Hash)
+
+      matrix = symbolize_matrix_keys(matrix)
+      return if matrix.nil?
+
+      axes = matrix.except(*MATRIX_CONTROL_KEYS)
+      includes = matrix_control_entries(matrix[:include])
+      excludes = matrix_control_entries(matrix[:exclude])
+      return if includes.nil? || excludes.nil?
+      return if axes.empty? && includes.empty?
+      return unless axes.all? { |_key, values| expandable_axis?(values) }
+
+      combinations = reject_excluded(expand_axes(axes), excludes)
+      apply_includes(combinations, includes, axes.keys)
+    end
+
+    def symbolize_matrix_keys(hash)
+      return unless hash.keys.all? { |key| key.is_a?(Symbol) || key.is_a?(String) }
+
+      hash.transform_keys(&:to_sym)
+    end
+
+    # @return [Array<Hash>, nil] normalized include/exclude rows, or nil when they are not statically usable
+    def matrix_control_entries(entries)
+      return [] if entries.nil?
+      return unless entries.is_a?(Array)
+
+      normalized = entries.map { |entry| matrix_control_entry(entry) }
+      return if normalized.any?(&:nil?)
+
+      normalized
+    end
+
+    def matrix_control_entry(entry)
+      return unless entry.is_a?(Hash) && entry.any?
+
+      normalized = symbolize_matrix_keys(entry)
+      return if normalized.nil? || !normalized.each_value.all? { |value| scalar_matrix_value?(value) }
+
+      normalized
+    end
+
+    def expandable_axis?(values)
+      values.is_a?(Array) && values.any? && values.all? { |value| scalar_matrix_value?(value) }
+    end
+
+    def scalar_matrix_value?(value)
+      !value.nil? && !value.is_a?(Hash) && !value.is_a?(Array)
+    end
+
+    # Cartesian product with the first axis varying slowest, matching GitHub's job order.
+    # An include-only matrix has no base combination: every include row is its own job.
+    def expand_axes(axes)
+      return [] if axes.empty?
+
+      axes.reduce([{}]) do |combinations, (key, values)|
+        combinations.flat_map { |combination| values.map { |value| combination.merge(key => value) } }
+      end
+    end
+
+    def reject_excluded(combinations, excludes)
+      combinations.reject do |combination|
+        excludes.any? { |exclusion| exclusion.all? { |key, value| combination.key?(key) && combination[key] == value } }
+      end
+    end
+
+    # An include row is merged into every combination it does not contradict on an
+    # axis key; rows that match nothing become their own combination.
+    def apply_includes(combinations, includes, axis_keys)
+      added = []
+
+      includes.each do |inclusion|
+        matched = false
+        combinations =
+          combinations.map do |combination|
+            next combination unless axis_keys.all? { |key| !inclusion.key?(key) || combination[key] == inclusion[key] }
+
+            matched = true
+            combination.merge(inclusion)
+          end
+        added << inclusion unless matched
+      end
+
+      combinations + added
     end
 
     def workflow_write

--- a/spec/ghb/application_spec.rb
+++ b/spec/ghb/application_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe(GHB::Application) do
         expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest)', 'Ruby Unit Tests (macos-26)']))
       end
 
-      it 'expands every axis when the matrix has multiple keys' do # rubocop:disable RSpec/ExampleLength
+      it 'joins every dimension of a multi-key matrix into a single check name' do # rubocop:disable RSpec/ExampleLength
         result =
           checks_for do |w|
             w.do_job(:tests) do
@@ -255,7 +255,134 @@ RSpec.describe(GHB::Application) do
             end
           end
 
-        expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest)', 'Ruby Unit Tests (3.3)', 'Ruby Unit Tests (3.4)']))
+        expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest, 3.3)', 'Ruby Unit Tests (ubuntu-latest, 3.4)']))
+      end
+
+      it 'expands the cartesian product with the first axis varying slowest' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { os: %w[ubuntu-latest macos-26], ruby: %w[3.3 3.4] } })
+            end
+          end
+
+        expect(result).to(
+          eq(
+            [
+              'Ruby Unit Tests (ubuntu-latest, 3.3)',
+              'Ruby Unit Tests (ubuntu-latest, 3.4)',
+              'Ruby Unit Tests (macos-26, 3.3)',
+              'Ruby Unit Tests (macos-26, 3.4)'
+            ]
+          )
+        )
+      end
+
+      it 'stringifies non-string matrix values the way GitHub does' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { version: [20, 3.4], experimental: [true] } })
+            end
+          end
+
+        expect(result).to(eq(['Ruby Unit Tests (20, true)', 'Ruby Unit Tests (3.4, true)']))
+      end
+
+      it 'accepts a matrix written with string keys' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ 'matrix' => { 'os' => %w[ubuntu-latest], 'ruby' => %w[3.3] } }) # rubocop:disable Style/StringHashKeys
+            end
+          end
+
+        expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest, 3.3)']))
+      end
+
+      it 'drops the combinations listed under exclude' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { os: %w[ubuntu-latest macos-26], ruby: %w[3.3 3.4], exclude: [{ os: 'macos-26', ruby: '3.3' }] } })
+            end
+          end
+
+        expect(result).to(
+          eq(['Ruby Unit Tests (ubuntu-latest, 3.3)', 'Ruby Unit Tests (ubuntu-latest, 3.4)', 'Ruby Unit Tests (macos-26, 3.4)'])
+        )
+      end
+
+      it 'merges an include row into every combination it matches' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { os: %w[ubuntu-latest macos-26], include: [{ os: 'macos-26', arch: 'arm64' }] } })
+            end
+          end
+
+        expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest)', 'Ruby Unit Tests (macos-26, arm64)']))
+      end
+
+      it 'adds an include row that matches nothing as its own combination' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { os: %w[ubuntu-latest], include: [{ os: 'windows-latest' }] } })
+            end
+          end
+
+        expect(result).to(eq(['Ruby Unit Tests (ubuntu-latest)', 'Ruby Unit Tests (windows-latest)']))
+      end
+
+      it 'treats each row of an include-only matrix as its own combination' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: { include: [{ site: 'production', datacenter: 'site-a' }, { site: 'staging', datacenter: 'site-b' }] } })
+            end
+          end
+
+        expect(result).to(eq(['Ruby Unit Tests (production, site-a)', 'Ruby Unit Tests (staging, site-b)']))
+      end
+
+      it "reproduces GitHub's documented include expansion" do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Build')
+              do_strategy(
+                {
+                  matrix:
+                    {
+                      fruit: %w[apple pear],
+                      animal: %w[cat dog],
+                      include: [{ color: 'green' }, { color: 'pink', animal: 'cat' }, { fruit: 'apple', shape: 'circle' }, { fruit: 'banana' }, { fruit: 'banana', animal: 'cat' }]
+                    }
+                }
+              )
+            end
+          end
+
+        expect(result).to(
+          eq(
+            [
+              'Build (apple, cat, pink, circle)',
+              'Build (apple, dog, green, circle)',
+              'Build (pear, cat, pink)',
+              'Build (pear, dog, green)',
+              'Build (banana)',
+              'Build (banana, cat)'
+            ]
+          )
+        )
       end
 
       it 'mixes bare and expanded names across jobs and preserves job order' do # rubocop:disable RSpec/ExampleLength
@@ -281,6 +408,93 @@ RSpec.describe(GHB::Application) do
 
         expect(result.first).to(eq('Ruby Linter'))
         expect(result.first).not_to(include('('))
+      end
+
+      it 'treats a job whose strategy is not a mapping as non-matrix' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:lint) { do_name('Ruby Linter') }
+            w.jobs[:lint].strategy = 'fail-fast'
+          end
+
+        expect(result).to(eq(['Ruby Linter']))
+      end
+
+      it 'skips a nil job entry' do # rubocop:disable RSpec/ExampleLength
+        result =
+          checks_for do |w|
+            w.do_job(:lint) { do_name('Ruby Linter') }
+            w.jobs[:broken] = nil
+          end
+
+        expect(result).to(eq(['Ruby Linter']))
+      end
+
+      describe 'matrices that cannot be expanded statically' do # rubocop:disable RSpec/NestedGroups
+        before { allow(app).to(receive(:warn)) }
+
+        def checks_for_matrix(matrix)
+          checks_for do |w|
+            w.do_job(:tests) do
+              do_name('Ruby Unit Tests')
+              do_strategy({ matrix: matrix })
+            end
+          end
+        end
+
+        it 'warns and emits no check name for a matrix built from an expression' do # rubocop:disable RSpec/MultipleExpectations
+          expect(checks_for_matrix('${{fromJson(needs.variables.outputs.matrix)}}')).to(eq([]))
+          expect(app).to(have_received(:warn).with(/cannot expand the matrix of job 'Ruby Unit Tests'/))
+        end
+
+        it 'warns and emits no check name for an axis whose values come from an expression' do # rubocop:disable RSpec/MultipleExpectations
+          expect(checks_for_matrix({ os: '${{fromJson(needs.variables.outputs.os)}}' })).to(eq([]))
+          expect(app).to(have_received(:warn).with(/skipping it in the required status checks/))
+        end
+
+        it 'emits no check name for an axis with no values' do
+          expect(checks_for_matrix({ os: [] })).to(eq([]))
+        end
+
+        it 'emits no check name for an axis holding non-scalar values' do
+          expect(checks_for_matrix({ config: [{ os: 'ubuntu-latest' }] })).to(eq([]))
+        end
+
+        it 'emits no check name for an axis holding a nil value' do
+          expect(checks_for_matrix({ os: [nil] })).to(eq([]))
+        end
+
+        it 'emits no check name for an empty matrix' do
+          expect(checks_for_matrix({})).to(eq([]))
+        end
+
+        it 'emits no check name when the matrix keys are not names' do
+          expect(checks_for_matrix({ 1 => %w[a b] })).to(eq([]))
+        end
+
+        it 'emits no check name when include is not a list' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], include: { os: 'macos-26' } })).to(eq([]))
+        end
+
+        it 'emits no check name when an include row is not a mapping' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], include: ['macos-26'] })).to(eq([]))
+        end
+
+        it 'emits no check name when an include row is empty' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], include: [{}] })).to(eq([]))
+        end
+
+        it 'emits no check name when an include row holds a non-scalar value' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], include: [{ os: 'ubuntu-latest', env: { 'DEBUG' => '1' } }] })).to(eq([])) # rubocop:disable Style/StringHashKeys
+        end
+
+        it 'emits no check name when an include row key is not a name' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], include: [{ 1 => 'macos-26' }] })).to(eq([]))
+        end
+
+        it 'emits no check name when exclude is not a list' do
+          expect(checks_for_matrix({ os: %w[ubuntu-latest], exclude: 'macos-26' })).to(eq([]))
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

`collect_required_status_checks` built required-check names by iterating each matrix axis independently, so a job with a two-key matrix (`{os: [ubuntu-latest, macos-26], ruby: ['3.3', '3.4']}`) produced `Job (ubuntu-latest)`, `Job (3.3)`, `Job (3.4)` — names that never match GitHub's real `Job (ubuntu-latest, 3.3)` check-run contexts. `include:` rows, being arrays of hashes, stringified as Ruby hash literals like `Job ({:os=>...})`. Because matrices are copied verbatim from user workflows, this triggers on any user-authored preserved job: `validate_required_checks!` raises on every run, or `--sync_required_status_checks` writes phantom contexts into branch protection that can never report, permanently blocking merges in consumer repos.

This replaces the per-axis loop with a real matrix expansion that reproduces GitHub's own naming.

**Key changes:**

- `lib/ghb/application.rb`: rewrote `collect_required_status_checks` around a new `matrix_combinations` helper — cartesian product of the axes in definition order (first axis varying slowest, matching GitHub's job order), `exclude:` combinations dropped first, then `include:` rows merged into every combination they do not contradict on an axis key, with unmatched include rows becoming their own combination. Names are emitted as `Job (v1, v2, ...)` in a single parenthesis.
- `lib/ghb/application.rb`: matrices that cannot be expanded statically — expression-driven `${{fromJson(...)}}` matrices or axes, empty or non-scalar axis values, malformed `include`/`exclude` — now emit a warning and contribute **no** check names, rather than emitting wrong ones. Also hardened against `nil` job entries and non-Hash strategies.
- `spec/ghb/application_spec.rb`: rewrote the two examples at lines 249-259 that enshrined the incorrect per-axis expansion, and added 22 examples covering cartesian order, value stringification, string keys, `exclude`, `include` merge / new-combination / include-only, GitHub's documented `include` expansion example verbatim, nil jobs, non-Hash strategies, and every un-expandable path.

**Test evidence**

- `bundle exec rspec` → `446 examples, 0 failures`.
- Regression direction confirmed: with `lib/ghb/application.rb` stashed, the spec reports `45 examples, 22 failures`; all pass with the fix applied.
- Changed region (`collect_required_status_checks` + the matrix helpers) coverage from the SimpleCov resultset: lines 59/59 (100.0%), branches 36/36 (100.0%). Repo-wide line 99.01%, branch 89.76% — both above the 80% thresholds.
- `bundle exec rubocop` → `56 files inspected, no offenses detected`.
- Smoke-tested against this repo's own `.github/workflows/build.yml`: single-axis check names are unchanged, so existing branch protection contexts here are undisturbed.

Fixes #474

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [x] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

The generated required-status-check names change for any consumer repo with a multi-dimension or `include:`-based matrix — that is the point of the fix, but it needs a deliberate action downstream rather than a silent upgrade.

Two cases to be aware of when rolling this out:

1. **Repos that already ran `--sync_required_status_checks` with a multi-dimension matrix** have phantom contexts (`Job (3.3)`) written into branch protection. Those contexts are not produced by the new code, so they will not be cleaned up automatically — re-run the sync so branch protection is rewritten with the correct `Job (ubuntu-latest, 3.3)` contexts, and confirm the stale ones are gone before relying on merges.
2. **Jobs with dynamic matrices** (`${{fromJson(...)}}`) previously emitted garbage names and now emit none at all, with a warning. That is deliberate — the names cannot be known statically, and emitting nothing is safer than emitting a context that can never report. Those jobs must be added to branch protection manually if they are meant to be required.

Single-axis matrices are unaffected: their names are byte-identical before and after, so the common case needs no action.

I chose full cartesian expansion over the issue's weaker "at minimum, warn or raise on multi-dimension matrices" fallback because the warn-only path would leave every multi-dimension consumer permanently unable to have those checks required. The un-expandable cases still take the warn path, so the safety valve is preserved exactly where the names genuinely cannot be derived.
