### PR TITLE
#472: Stop injecting the org-scoped GH_PAT into dependency and test steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,12 +189,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y bats
         fi
       env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"
+        GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
     - name: Bats
       shell: bash
       run: bats tests/
-      env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"
   ruby_unit_tests:
     name: Ruby Unit Tests
     runs-on: "${{matrix.os}}"
@@ -218,9 +216,7 @@ jobs:
       shell: bash
       run: echo "Already done by setup."
       env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"
+        GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
     - name: RSpec
       shell: bash
       run: bundle exec rspec --format documentation
-      env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"

--- a/lib/ghb/language_job_builder.rb
+++ b/lib/ghb/language_job_builder.rb
@@ -18,9 +18,38 @@ module GHB
     # How many directory levels below the repo root a sub-project dependency file
     # may sit and still be detected (e.g. js/<module>/package-lock.json is 2 deep).
     SUBDIR_DEPENDENCY_SCAN_DEPTH = 2
-    private_constant :SWIFT_DEPLOY_CHECK_FLAGS, :CODEDEPLOY_SETUP_LANGUAGES, :SUBDIR_DEPENDENCY_SCAN_DEPTH
+    # Token exposed to dependency-install steps. Deliberately the ephemeral, repo-scoped
+    # secrets.GITHUB_TOKEN and NOT secrets.GH_PAT (SEC-001): install steps execute arbitrary
+    # third-party code (postinstall hooks, plugins), so an org-scoped long-lived PAT in their
+    # environment is one malicious transitive dependency away from exfiltration.
+    #
+    # Kept rather than dropped because Tuist's SwiftPM resolution reads GITHUB_TOKEN/GH_TOKEN.
+    # The other package managers authenticate by other means and are unaffected: Composer via
+    # the github-oauth config setup-php writes from the run token, Bundler via
+    # BUNDLE_GITHUB__COM, npm/yarn/pnpm via NODE_AUTH_TOKEN, Carthage via GITHUB_ACCESS_TOKEN,
+    # and private sibling repos over SSH through webfactory/ssh-agent with secrets.SSH_KEY.
+    # It also raises the API rate limit from 60/hour per runner IP to 1,000/hour per
+    # repository -- and unlike the PAT's 5,000/hour shared across every repo and workflow,
+    # that budget is isolated per repo, so concurrent builds no longer contend.
+    #
+    # Unit-test steps get no token at all: none of the supported test frameworks read one.
+    DEPENDENCY_STEP_TOKEN = '${{secrets.GITHUB_TOKEN}}'
+    # The PAT reference this tool used to inject, kept so regeneration can recognise and strip
+    # it from workflows generated before SEC-001 was fixed.
+    INJECTED_PAT = '${{secrets.GH_PAT}}'
+    private_constant :SWIFT_DEPLOY_CHECK_FLAGS, :CODEDEPLOY_SETUP_LANGUAGES, :SUBDIR_DEPENDENCY_SCAN_DEPTH, :DEPENDENCY_STEP_TOKEN, :INJECTED_PAT
 
     attr_reader :code_deploy_pre_steps, :dependencies_steps, :dependencies_commands
+
+    # Steps inherit their env from the previously generated workflow via copy_properties, so
+    # simply no longer injecting the PAT would leave it in place forever in every repo that
+    # already has one written. Strip it on regeneration -- but only when the value is exactly
+    # the PAT reference this tool used to inject, so a GITHUB_TOKEN the user set deliberately
+    # (or already migrated to secrets.GITHUB_TOKEN) is left alone.
+    def self.drop_injected_pat(env)
+      env.delete('GITHUB_TOKEN') if env['GITHUB_TOKEN'] == INJECTED_PAT
+      env.delete(:GITHUB_TOKEN) if env[:GITHUB_TOKEN] == INJECTED_PAT
+    end
 
     def initialize(context:, unit_tests_conditions:, dependencies_commands:)
       @options = context.options
@@ -240,7 +269,7 @@ module GHB
           copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
           do_shell('bash')
           do_run(dependency[:package_manager_default]) if run.nil?
-          env['GITHUB_TOKEN'] = '${{secrets.GH_PAT}}'
+          env['GITHUB_TOKEN'] = DEPENDENCY_STEP_TOKEN
           code_deploy_pre_steps << duplicate(self) if needs_codedeploy_setup
           dependencies_commands_additions << dependency[:package_manager_update] if dependency[:package_manager_update]
         end
@@ -251,7 +280,7 @@ module GHB
           copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
           do_shell('bash')
           do_run(language[:unit_test_framework_default]) if run.nil?
-          env['GITHUB_TOKEN'] = '${{secrets.GH_PAT}}'
+          LanguageJobBuilder.drop_injected_pat(env)
         end
       end
 
@@ -270,7 +299,7 @@ module GHB
           copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
           do_shell('bash')
           do_run("cd #{subdir} && #{dep[:package_manager_default]}") if run.nil?
-          env['GITHUB_TOKEN'] = '${{secrets.GH_PAT}}'
+          env['GITHUB_TOKEN'] = DEPENDENCY_STEP_TOKEN
           # Sub-project update commands run from the repo root in a single combined
           # block, so each must cd into its own folder; a subshell keeps the cwd
           # local so the next command still starts from the root.
@@ -281,7 +310,7 @@ module GHB
           copy_properties(find_step(old_workflow.jobs[:"#{language[:short_name]}_unit_tests"]&.steps, name))
           do_shell('bash')
           do_run("cd #{subdir} && #{language[:unit_test_framework_default]}") if run.nil?
-          env['GITHUB_TOKEN'] = '${{secrets.GH_PAT}}'
+          LanguageJobBuilder.drop_injected_pat(env)
         end
       end
     end

--- a/lib/ghb/workflow/workflow.rb
+++ b/lib/ghb/workflow/workflow.rb
@@ -144,9 +144,11 @@ module GHB
       data = rewrite_github_refs(to_h.deep_stringify_keys)
       content = header + data.to_yaml({ line_width: -1 })
 
-      # Convert secrets.GITHUB_TOKEN to secrets.GH_PAT for higher rate limits
-      content.gsub!('${{secrets.GITHUB_TOKEN}}', '${{secrets.GH_PAT}}') unless file.match?(/auto-(merge|approve)/)
-
+      # NOTE: secrets.GITHUB_TOKEN is deliberately NOT rewritten to secrets.GH_PAT here (SEC-001).
+      # The blanket rewrite put a long-lived, org-scoped PAT into the environment of every step
+      # that runs third-party code, and it silently overrode a GITHUB_TOKEN a user wrote on
+      # purpose in a preserved job. Steps that genuinely need cross-repo or PR-creation rights
+      # request secrets.GH_PAT explicitly instead.
       File.write(file, content)
     end
 

--- a/spec/fixtures/workflow_generation/build.yml
+++ b/spec/fixtures/workflow_generation/build.yml
@@ -125,9 +125,7 @@ jobs:
       shell: bash
       run: bundle install
       env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"
+        GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
     - name: RSpec
       shell: bash
       run: bundle exec rspec --format documentation
-      env:
-        GITHUB_TOKEN: "${{secrets.GH_PAT}}"

--- a/spec/ghb/language_job_builder_spec.rb
+++ b/spec/ghb/language_job_builder_spec.rb
@@ -602,6 +602,88 @@ RSpec.describe(GHB::LanguageJobBuilder) do # rubocop:disable RSpec/MultipleMemoi
       expect(new_workflow.env).not_to(have_key(:'MYSQL-VERSION'))
     end
 
+    # SEC-001: dependency-install steps run arbitrary third-party code, so they must never see
+    # the long-lived org-scoped PAT. They keep an ephemeral repo-scoped token because Tuist's
+    # SwiftPM resolution reads GITHUB_TOKEN; unit-test steps get no token at all.
+    describe 'token exposure in generated steps' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      def go_steps
+        stub_config_file_reads(go_language_yaml)
+        stub_go_language_detection
+        builder.build
+        new_workflow.jobs[:go_unit_tests].steps
+      end
+
+      it 'gives the dependency-install step the ephemeral token, never the PAT', :aggregate_failures do
+        install_step = go_steps.find { |step| step.name == 'Go Modules' }
+
+        expect(install_step.env['GITHUB_TOKEN']).to(eq('${{secrets.GITHUB_TOKEN}}'))
+        expect(install_step.env.values).not_to(include('${{secrets.GH_PAT}}'))
+      end
+
+      it 'gives the unit-test step no token at all', :aggregate_failures do
+        test_step = go_steps.find { |step| step.name == 'Testing' }
+
+        expect(test_step.env).not_to(have_key('GITHUB_TOKEN'))
+        expect(test_step.env.values).not_to(include('${{secrets.GH_PAT}}'))
+      end
+
+      it 'keeps the PAT out of every run step in the generated job' do
+        run_steps = go_steps.reject { |step| step.run.nil? }
+
+        expect(run_steps.flat_map { |step| step.env.values }).not_to(include('${{secrets.GH_PAT}}'))
+      end
+
+      # The setup action fetches the private ci-actions repo, so its github-token input
+      # legitimately keeps the PAT -- this is the boundary of the SEC-001 change.
+      it 'still passes the PAT to the setup action that needs cross-repo rights' do
+        setup_step = go_steps.find { |step| step.name == 'Setup' }
+
+        expect(setup_step.with[:'github-token']).to(eq('${{secrets.GH_PAT}}'))
+      end
+
+      # Migration path: steps inherit env from the previously generated workflow via
+      # copy_properties, so a repo generated before this fix carries the PAT on its test step.
+      # Regeneration must strip it, or the exposure survives the upgrade indefinitely.
+      context 'when regenerating a workflow that already carries the injected PAT' do # rubocop:disable RSpec/NestedGroups,RSpec/MultipleMemoizedHelpers
+        before do
+          old_workflow.do_job(:go_unit_tests) do
+            do_name('Go Unit Tests')
+            do_step('Testing') { do_env({ 'GITHUB_TOKEN' => '${{secrets.GH_PAT}}' }) } # rubocop:disable Style/StringHashKeys
+            do_step('Go Modules') { do_env({ 'GITHUB_TOKEN' => '${{secrets.GH_PAT}}' }) } # rubocop:disable Style/StringHashKeys
+          end
+        end
+
+        it 'strips the inherited PAT from the unit-test step', :aggregate_failures do
+          test_step = go_steps.find { |step| step.name == 'Testing' }
+
+          expect(test_step.env).not_to(have_key('GITHUB_TOKEN'))
+          expect(test_step.env.values).not_to(include('${{secrets.GH_PAT}}'))
+        end
+
+        it 'downgrades the inherited PAT on the dependency-install step' do
+          install_step = go_steps.find { |step| step.name == 'Go Modules' }
+
+          expect(install_step.env['GITHUB_TOKEN']).to(eq('${{secrets.GITHUB_TOKEN}}'))
+        end
+      end
+
+      # Only the value this tool injected is stripped; a token the user set on purpose stays.
+      context 'when the user set their own token on the unit-test step' do # rubocop:disable RSpec/NestedGroups,RSpec/MultipleMemoizedHelpers
+        before do
+          old_workflow.do_job(:go_unit_tests) do
+            do_name('Go Unit Tests')
+            do_step('Testing') { do_env({ 'GITHUB_TOKEN' => '${{secrets.MY_OWN_TOKEN}}' }) } # rubocop:disable Style/StringHashKeys
+          end
+        end
+
+        it 'leaves a user-chosen token untouched' do
+          test_step = go_steps.find { |step| step.name == 'Testing' }
+
+          expect(test_step.env['GITHUB_TOKEN']).to(eq('${{secrets.MY_OWN_TOKEN}}'))
+        end
+      end
+    end
+
     it 'does not enable a service the language declares no marker for', :aggregate_failures do # rubocop:disable RSpec/ExampleLength
       markerless_config = go_language_config.deep_stringify_keys
       markerless_config['go']['dependencies'].first.delete('mysql_dependency')

--- a/spec/ghb/workflow/workflow_spec.rb
+++ b/spec/ghb/workflow/workflow_spec.rb
@@ -324,13 +324,39 @@ RSpec.describe(GHB::Workflow) do # rubocop:disable RSpec/SpecFilePathFormat
       end
     end
 
-    it 'converts secrets.GITHUB_TOKEN to secrets.GH_PAT' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+    # SEC-001 regression guard: the writer used to blanket-rewrite every
+    # secrets.GITHUB_TOKEN into secrets.GH_PAT, silently swapping an ephemeral
+    # repo-scoped token for a long-lived org-scoped PAT -- including in jobs the
+    # user wrote by hand. The token a caller asks for is the token that ships.
+    it 'preserves secrets.GITHUB_TOKEN instead of rewriting it to secrets.GH_PAT' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
       workflow.do_env({ TOKEN: '${{secrets.GITHUB_TOKEN}}' })
+      workflow.write(temp_file)
+
+      expect(File).to(have_received(:write)) do |_, content|
+        expect(content).to(include('${{secrets.GITHUB_TOKEN}}'))
+        expect(content).not_to(include('${{secrets.GH_PAT}}'))
+      end
+    end
+
+    it 'leaves an explicitly requested secrets.GH_PAT untouched' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      workflow.do_env({ TOKEN: '${{secrets.GH_PAT}}' })
       workflow.write(temp_file)
 
       expect(File).to(have_received(:write)) do |_, content|
         expect(content).to(include('${{secrets.GH_PAT}}'))
         expect(content).not_to(include('${{secrets.GITHUB_TOKEN}}'))
+      end
+    end
+
+    # The old rewrite exempted auto-merge/auto-approve by filename; with the rewrite gone
+    # the filename must no longer influence the token that is written.
+    it 'writes the same token regardless of the workflow filename' do # rubocop:disable RSpec/ExampleLength,RSpec/MultipleExpectations
+      workflow.do_env({ TOKEN: '${{secrets.GITHUB_TOKEN}}' })
+      workflow.write('.github/workflows/auto-approve.yml')
+
+      expect(File).to(have_received(:write)) do |_, content|
+        expect(content).to(include('${{secrets.GITHUB_TOKEN}}'))
+        expect(content).not_to(include('${{secrets.GH_PAT}}'))
       end
     end
 


### PR DESCRIPTION
## Summary

A long-lived, org-scoped PAT was sitting in the environment of every step that executes third-party code. Two mechanisms put it there: the workflow writer blanket-rewrote every `${{secrets.GITHUB_TOKEN}}` to `${{secrets.GH_PAT}}` on write (`workflow.rb:147-148`, exempting only auto-merge/approve by filename), and the language job builder injected `GITHUB_TOKEN=${{secrets.GH_PAT}}` into all four dependency-install and unit-test step sites. So `bundle install`, `npm install`, `composer install`, `bundle exec rspec` and `bats tests/` all ran with an org-wide credential readable from `ENV` — one malicious postinstall hook or transitive dependency away from exfiltration, on every push and same-repo PR, in this repo and every consumer repo that regenerates. It also silently defeated the `permissions: contents: read` ceiling those workflows otherwise declare, since that ceiling only constrains the ephemeral token.

Before changing anything I audited which of the generated commands actually consume `GITHUB_TOKEN`. **Exactly one does** — Tuist's SwiftPM resolution reads `GITHUB_TOKEN`/`GH_TOKEN`. Every other package manager authenticates by other means: Composer via the `github-oauth` config that `shivammathur/setup-php` writes from the run's own token (its `github-token` input defaults to `${{ github.token }}` and `ci-actions/setup` does not override it), Bundler via `BUNDLE_GITHUB__COM`, npm/yarn/pnpm via `NODE_AUTH_TOKEN`, Carthage via `GITHUB_ACCESS_TOKEN` (not `GITHUB_TOKEN`), and private sibling repos over SSH through `webfactory/ssh-agent` with `secrets.SSH_KEY`. **None of the ten supported test frameworks read a token at all.**

So install steps keep a `GITHUB_TOKEN` — sourced from the ephemeral repo-scoped secret — and test steps get none.

**Key changes:**

- `lib/ghb/workflow/workflow.rb`: removed the blanket `gsub!`. Beyond the security issue this was a correctness bug — it silently overrode a `secrets.GITHUB_TOKEN` a user wrote deliberately in a preserved job, and made the choice depend on the workflow's filename. A comment records why it must not come back.
- `lib/ghb/language_job_builder.rb`: the two dependency-install sites now use `DEPENDENCY_STEP_TOKEN = '${{secrets.GITHUB_TOKEN}}'`; the two unit-test sites emit no token.
- `lib/ghb/language_job_builder.rb`: added `drop_injected_pat`, because removing the injection alone was **not** enough — see Further comments.
- `spec/ghb/workflow/workflow_spec.rb`: the example asserting the rewrite happened pinned the buggy behavior; rewritten to assert `secrets.GITHUB_TOKEN` is preserved, plus new examples that an explicitly requested `GH_PAT` is left alone and that the filename no longer influences the token written.
- `spec/ghb/language_job_builder_spec.rb`: new `token exposure in generated steps` group — install step gets the ephemeral token, test step gets none, no PAT on any run step, the setup action still receives the PAT it legitimately needs, both migration cases, and a user-chosen token surviving untouched.
- `spec/fixtures/workflow_generation/build.yml` and `.github/workflows/build.yml`: regenerated.

**Scope boundary:** `secrets.GH_PAT` is untouched where it is genuinely required — the `github-token` inputs to `cloud-officer/ci-actions/setup` and `soup` (which fetch private repos), and the dependencies/auto-approve/external-actions-bump workflows that open and approve PRs. Ten such references remain in the regenerated `build.yml`, all of them `github-token:` action inputs.

**Test evidence**

- `bundle exec rspec` → `482 examples, 0 failures`; line coverage 1709/1725 (99.07%), branch 590/659 (89.52%), both above the 80% floor.
- Regression direction confirmed: with the two lib files stashed, the new guards report `4 failures`; all pass with the fix applied.
- `bats tests/` → `1..32`, all `ok`. `bundle exec rubocop` → `56 files inspected, no offenses detected`.
- Regenerated this repo's `build.yml` with the modified tool and verified the PAT is gone from all four steps.

Closes #472

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

**Removing the injection was not sufficient on its own, and this is the part most worth reviewing.** Generated steps inherit their `env` from the previously generated workflow via `copy_properties`. When I first regenerated this repo's `build.yml` with the injection removed, the RSpec and Bats steps *still* carried `GITHUB_TOKEN: ${{secrets.GH_PAT}}` — inherited from the file on disk. Left that way, every consumer repo would have kept the PAT on its test steps indefinitely and the fix would have been cosmetic. The install sites did not have this problem because their assignment overwrites the inherited value.

`drop_injected_pat` therefore strips the key on regeneration, but **only when the value is exactly the PAT string this tool used to inject**, so a `GITHUB_TOKEN` a user set on purpose is preserved. Two specs cover both directions. The golden-file fixture could not have caught this class of bug at all, since it generates from a clean slate with no prior workflow to inherit from.

**Rollout:** consumer repos only pick this up when they regenerate their workflows; until then their existing `build.yml` still carries the PAT. Worth coordinating with the fleet update. Separately — and explicitly out of scope for this PR per the issue — the `GH_PAT` secret has been exposed to arbitrary third-party code in test steps across every consumer repo for as long as this behavior has existed, so rotating it is a reasonable precaution once the fleet has regenerated.

**Rate limits, since the PAT was originally introduced "for higher rate limits":** this should improve them rather than regress them. An unauthenticated caller gets 60 requests/hour per runner IP; `secrets.GITHUB_TOKEN` gets 1,000/hour **per repository**, isolated; a PAT gets 5,000/hour **per user** — a single bucket shared across every repo, workflow and step that uses it. Concurrent builds across the org were contending for that one shared budget, which matches the reported symptom of intermittent limits when many builds run in the same hour. Per-repo isolation removes that contention. Composer specifically is unaffected either way, since its authentication comes from the `github-oauth` config `setup-php` writes, not from this environment variable.
