### PR TITLE
Fix #488: clear the force-push actor allowlist REST silently ignores

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -291,7 +291,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 ### GHB::GitHubAPIClient
 
-**Purpose:** Centralized GitHub REST API client with shared headers, bounded timeouts, rate-limit-aware retries, and error handling. Raises `GHB::GitHubAPIError` (carrying a truncated response body) when a response code falls outside the caller's `expected_codes`.
+**Purpose:** Centralized GitHub REST and GraphQL API client with shared headers, bounded timeouts, rate-limit-aware retries, and error handling. Raises `GHB::GitHubAPIError` (carrying a truncated response body) when a response code falls outside the caller's `expected_codes`.
 
 **Location:** `lib/ghb/github_api_client.rb`
 
@@ -302,6 +302,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 - `put(url, body:, expected_codes:)`: HTTP PUT with response validation
 - `post(url, body:, headers:, expected_codes:)`: HTTP POST with response validation
 - `patch(url, body:, expected_codes:)`: HTTP PATCH with response validation
+- `graphql(query, variables:)`: Runs a GraphQL query or mutation against `https://api.github.com/graphql` (bearer auth) and returns its `data` hash. GraphQL reports failures inside a 200 response's `errors` array rather than through the status code, so those — and a body that is not valid JSON — are raised as `GHB::GitHubAPIError` just like a failed REST call. Used for the settings the classic REST API cannot represent, notably branch-protection actor allowlists
 
 **Private Methods:**
 
@@ -510,7 +511,7 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 ### GHB::RepositoryConfigurator
 
-**Purpose:** Configures GitHub repository settings including branch protection rules, security features (vulnerability alerts, secret scanning, CodeQL), and repository options via the GitHub REST API.
+**Purpose:** Configures GitHub repository settings including branch protection rules, security features (vulnerability alerts, secret scanning, CodeQL), and repository options via the GitHub REST API, falling back to GraphQL for the one setting REST cannot express (the force-push actor allowlist).
 
 **Location:** `lib/ghb/repository_configurator.rb`
 
@@ -521,13 +522,17 @@ github-build is a Ruby CLI tool that automatically generates and updates GitHub 
 
 **Private Methods:**
 
-- `configure_branch_protection(github_client, repo_url, current_protection, protection_exists)`: Assembles the expected check list (generated jobs, augmented checks, Xcode Cloud checks), validates it, applies the branch protection payload, and enables required signatures
+- `configure_branch_protection(github_client, repo_url, current_protection, protection_exists, repository)`: Assembles the expected check list (generated jobs, augmented checks, Xcode Cloud checks), validates it, applies the branch protection payload, enables required signatures, and enforces the force-push allowlist
 - `augment_required_status_checks`: Adds integration-derived checks to the collected list — a `Vercel` check when `package.json` declares `"next"`, plus the job names of a hand-maintained `.github/workflows/smoke.yml` (read dynamically, since that workflow is intentionally not generated). CodeQL checks are deliberately excluded: default setup runs in "smart mode" and only on relevant file changes, so it blocks PRs through code scanning alerts rather than a required check
 - `log_codeql_languages(github_client, repo_url)`: Reports the languages CodeQL default setup covers (filtering the redundant `javascript-typescript` / `typescript` entries the API returns alongside `javascript`); informational only — it contributes no required checks
 - `discover_xcode_cloud_checks(github_client, repo_url, actual_checks, expected_checks, protection_exists)`: Returns Xcode Cloud checks when a `ci_scripts` directory exists, dispatching to the protection-based or commit-status-based discovery below
 - `required_checks_differ?(expected_checks, actual_checks)`: Returns whether the two check lists differ in either direction
 - `validate_required_checks!(expected_checks, actual_checks, protection_exists)`: Prints the missing/extra checks and raises on a mismatch unless `--sync_required_status_checks` is set
 - `build_branch_protection_payload(current_protection, expected_checks, protection_exists, sync_required_status_checks)`: Builds the PUT body — reusing the remote check list unless syncing, preserving `app_id` values when syncing, and `filter_map`-ing dismissal/bypass users and teams so the payload never carries a `[null]` array (which GitHub rejects with 422)
+- `enforce_force_push_allowlist(github_client, repository)`: Reads the default branch's force-push actor allowlist over GraphQL after the PUT and clears it when non-empty. The `allow_force_pushes: false` sent in the PUT is silently a no-op while that allowlist exists — the PUT still returns 200, but the branch stays force-pushable and REST reports the same `allow_force_pushes` boolean for "nobody may force push" and "only these actors may". Names every actor found and raises if the list survives clearing, so the run never reports success over a rewritable branch history
+- `fetch_branch_protection_rule(github_client, repository)`: Fetches the classic branch protection rule (id plus `bypassForcePushAllowances`) for `refs/heads/<default_branch>`. Returns `nil` when no rule exists, and warns without failing when GraphQL is unreachable — an unreadable allowlist is undetected drift, not proven drift
+- `clear_force_push_allowlist(github_client, rule_id)`: Runs `updateBranchProtectionRule(bypassForcePushActorIds: [])` and returns the actors GitHub still reports as allowed, re-verifying the mutation in the same round trip
+- `force_push_actors(rule)`: Flattens `bypassForcePushAllowances` nodes into `User <login>` / `Team <slug>` / `App <slug>` labels for the warnings and error message
 - `discover_xcode_cloud_checks_from_protection(actual_checks, expected_checks)`: Extracts Xcode Cloud checks from existing branch protection by finding checks not in the expected set
 - `discover_xcode_cloud_checks_from_statuses(github_client, repo_url)`: Discovers Xcode Cloud checks from commit statuses on the default branch for new repos without existing protection
 - `configure_repository_options(github_client, repo_url)`: Applies merge strategy, wiki/projects, and delete-branch-on-merge settings
@@ -714,15 +719,17 @@ All dependencies are managed via Bundler with versions locked in `Gemfile.lock`.
 6. Validates existing checks match expected checks (only for existing protection); on mismatch, raises an error unless `--sync_required_status_checks` is set, in which case the remote check list is rebuilt from `expected_checks` while preserving `app_id` values for existing entries (so integration-specific configurations such as Xcode Cloud checks are not clobbered)
 7. Builds the protection payload, preserving existing dismissal restrictions and bypass allowances while dropping entries GitHub returns without a `login`/`slug` so the request body never contains a `[null]` users/teams array
 8. Configures branch protection with required status checks, code-owner review enforcement (`require_code_owner_reviews: true`), pull request reviews, and conversation resolution, then enables required signatures via the separate `required_signatures` endpoint
-9. Configures repository options: enables vulnerability alerts and automated security fixes, disables wiki and projects, configures merge strategies, and enables delete branch on merge
-10. Enables secret scanning features (push protection, validity checks, non-provider patterns, AI detection) for public repos; disables them for private repos (GHAS cost avoidance)
-11. Enables CodeQL default setup for public repos; disables it for private repos (GHAS cost avoidance)
+9. Reads the default branch's force-push actor allowlist over GraphQL and clears it when non-empty, because `allow_force_pushes: false` in the REST payload is silently ignored while that allowlist exists; the actors are named in the output and an allowlist that survives clearing fails the run
+10. Configures repository options: enables vulnerability alerts and automated security fixes, disables wiki and projects, configures merge strategies, and enables delete branch on merge
+11. Enables secret scanning features (push protection, validity checks, non-provider patterns, AI detection) for public repos; disables them for private repos (GHAS cost avoidance)
+12. Enables CodeQL default setup for public repos; disables it for private repos (GHAS cost avoidance)
 
 **Security Considerations:**
 
 - Uses GITHUB_TOKEN for API authentication via `GitHubAPIClient`
 - Validates branch protection before modification
 - Preserves existing dismissal restrictions and bypass allowances
+- Verifies over GraphQL that the default branch is actually not force-pushable, since the REST `allow_force_pushes` boolean cannot distinguish "nobody may force push" from "these actors may"
 - Handles new repositories without existing branch protection gracefully
 
 ### Gitignore Template Detection

--- a/lib/ghb/github_api_client.rb
+++ b/lib/ghb/github_api_client.rb
@@ -10,6 +10,7 @@ require_relative '../ghb'
 module GHB
   # Centralized GitHub API client with shared headers, retry logic, and error handling.
   class GitHubAPIClient
+    GRAPHQL_URL = 'https://api.github.com/graphql'
     MAX_RETRIES = 3
     # Cap a single rate-limit back-off so a far-future X-RateLimit-Reset can't hang CI.
     MAX_RETRY_WAIT = 60
@@ -19,6 +20,7 @@ module GHB
     READ_TIMEOUT = 30
     RETRYABLE_ERRORS = [Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError].freeze
 
+    private_constant :GRAPHQL_URL
     private_constant :MAX_RETRIES
     private_constant :MAX_RETRY_WAIT
     private_constant :OPEN_TIMEOUT
@@ -26,6 +28,7 @@ module GHB
     private_constant :RETRYABLE_ERRORS
 
     def initialize(token)
+      @token = token
       @headers = {
         Authorization: "token #{token}",
         Accept: 'application/vnd.github.v3+json'
@@ -46,6 +49,37 @@ module GHB
 
     def patch(url, body: nil, expected_codes: [200])
       execute(:patch, url, body: body, expected_codes: expected_codes)
+    end
+
+    # Runs a GraphQL query or mutation and returns its `data` hash.
+    #
+    # GraphQL is needed for the settings the classic REST API cannot represent
+    # (notably branch-protection actor allowlists). It reports failures inside a
+    # 200 response's `errors` array rather than through the status code, so those
+    # are surfaced here as GitHubAPIError just like a failed REST call.
+    def graphql(query, variables: {})
+      response = execute(
+        :post,
+        GRAPHQL_URL,
+        body: { query: query, variables: variables },
+        headers: { Authorization: "bearer #{@token}", Accept: 'application/json' }
+      )
+
+      payload =
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError => e
+          raise(GitHubAPIError, "GraphQL response was not valid JSON: #{e.message}")
+        end
+
+      errors = payload['errors']
+
+      if errors.is_a?(Array) && errors.any?
+        messages = errors.filter_map { |error| error['message'] }
+        raise(GitHubAPIError, "GraphQL request failed: #{messages.join('; ')}")
+      end
+
+      payload['data'] || {}
     end
 
     private

--- a/lib/ghb/repository_configurator.rb
+++ b/lib/ghb/repository_configurator.rb
@@ -9,6 +9,60 @@ require_relative 'github_api_client'
 module GHB
   # Configures GitHub repository settings including branch protection, security features, and CodeQL.
   class RepositoryConfigurator
+    # Reads the force-push actor allowlist for the default branch. The classic REST
+    # branch-protection API does not expose this list at all: it collapses "nobody may
+    # force push" and "only these actors may force push" into the same
+    # allow_force_pushes boolean, so a REST read cannot tell the two apart.
+    FORCE_PUSH_ALLOWANCES_QUERY = <<~GRAPHQL
+      query($owner: String!, $repository: String!, $qualifiedName: String!) {
+        repository(owner: $owner, name: $repository) {
+          ref(qualifiedName: $qualifiedName) {
+            branchProtectionRule {
+              id
+              allowsForcePushes
+              bypassForcePushAllowances(first: 100) {
+                nodes {
+                  actor {
+                    __typename
+                    ... on User { login }
+                    ... on Team { slug }
+                    ... on App { slug }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    # Empties the allowlist. Selecting the allowances back out of the mutation result
+    # re-verifies the change in the same round trip, so the caller never has to trust
+    # that the mutation did what it said.
+    CLEAR_FORCE_PUSH_ALLOWANCES_MUTATION = <<~GRAPHQL
+      mutation($ruleId: ID!) {
+        updateBranchProtectionRule(input: { branchProtectionRuleId: $ruleId, bypassForcePushActorIds: [] }) {
+          branchProtectionRule {
+            id
+            allowsForcePushes
+            bypassForcePushAllowances(first: 100) {
+              nodes {
+                actor {
+                  __typename
+                  ... on User { login }
+                  ... on Team { slug }
+                  ... on App { slug }
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    private_constant :FORCE_PUSH_ALLOWANCES_QUERY
+    private_constant :CLEAR_FORCE_PUSH_ALLOWANCES_MUTATION
+
     def initialize(options:, required_status_checks:, default_branch: 'master')
       @options = options
       @required_status_checks = required_status_checks
@@ -37,7 +91,7 @@ module GHB
       protection_exists = response.code == 200
       current_protection = protection_exists ? JSON.parse(response.body) : {}
 
-      configure_branch_protection(github_client, repo_url, current_protection, protection_exists)
+      configure_branch_protection(github_client, repo_url, current_protection, protection_exists, repository)
       configure_repository_options(github_client, repo_url)
       if is_private
         disable_security_features(github_client, repo_url)
@@ -52,7 +106,7 @@ module GHB
 
     private
 
-    def configure_branch_protection(github_client, repo_url, current_protection, protection_exists)
+    def configure_branch_protection(github_client, repo_url, current_protection, protection_exists, repository)
       augment_required_status_checks
       log_codeql_languages(github_client, repo_url)
 
@@ -76,6 +130,80 @@ module GHB
         "#{repo_url}/branches/#{@default_branch}/protection/required_signatures",
         expected_codes: [200, 204]
       )
+
+      enforce_force_push_allowlist(github_client, repository)
+    end
+
+    # The `allow_force_pushes: false` sent in the PUT above is silently a no-op when
+    # the branch sits in GitHub's "Allow force pushes -> Specify who can force push"
+    # mode: the PUT still returns 200 and the rest of the payload applies, but the
+    # actor allowlist survives and the branch stays force-pushable. Only GraphQL can
+    # see that list, and only GraphQL can empty it, so read it back here and clear it,
+    # rather than reporting success over a branch history anyone on the list can rewrite.
+    def enforce_force_push_allowlist(github_client, repository)
+      puts('    Checking force-push allowlist...')
+
+      rule = fetch_branch_protection_rule(github_client, repository)
+      return if rule.nil?
+
+      actors = force_push_actors(rule)
+
+      if actors.empty?
+        puts('        No force-push actor allowlist')
+        return
+      end
+
+      warn("        WARNING: #{@default_branch} is force-pushable despite allow_force_pushes: false — #{actors.length} actor(s) on the force-push allowlist:")
+      actors.each { |actor| warn("          ! #{actor}") }
+
+      remaining = clear_force_push_allowlist(github_client, rule['id'])
+      raise("Error: force-push allowlist on #{@default_branch} not cleared, still allows: #{remaining.join(', ')}") if remaining.any?
+
+      puts('        Force-push allowlist cleared')
+    end
+
+    # Returns the branch protection rule covering the default branch, or nil when there
+    # is none. A GraphQL failure (a token without GraphQL access, say) leaves the drift
+    # undetectable rather than proven, so it warns and lets the run continue; a proven
+    # non-empty allowlist is what fails the run, in enforce_force_push_allowlist above.
+    def fetch_branch_protection_rule(github_client, repository)
+      data = github_client.graphql(
+        FORCE_PUSH_ALLOWANCES_QUERY,
+        variables: {
+          owner: @options.organization,
+          repository: repository,
+          qualifiedName: "refs/heads/#{@default_branch}"
+        }
+      )
+
+      rule = data.dig('repository', 'ref', 'branchProtectionRule')
+      puts('        No classic branch protection rule found for the default branch') if rule.nil?
+      rule
+    rescue GitHubAPIError => e
+      warn("        WARNING: could not read the force-push allowlist over GraphQL: #{e.message}")
+      nil
+    end
+
+    # Empties the allowlist and returns whatever GitHub reports as still allowed
+    # (empty on success).
+    def clear_force_push_allowlist(github_client, rule_id)
+      puts('        Clearing force-push allowlist...')
+      data = github_client.graphql(CLEAR_FORCE_PUSH_ALLOWANCES_MUTATION, variables: { ruleId: rule_id })
+      force_push_actors(data.dig('updateBranchProtectionRule', 'branchProtectionRule') || {})
+    rescue GitHubAPIError => e
+      raise("Error: could not clear the force-push allowlist on #{@default_branch}: #{e.message}")
+    end
+
+    # Flattens bypassForcePushAllowances into "User octocat" / "Team core-team" labels.
+    def force_push_actors(rule)
+      nodes = rule.dig('bypassForcePushAllowances', 'nodes') || []
+
+      nodes.filter_map do |node|
+        actor = node&.dig('actor')
+        next unless actor
+
+        "#{actor['__typename'] || 'Actor'} #{actor['login'] || actor['slug'] || '(unnamed)'}"
+      end
     end
 
     def augment_required_status_checks

--- a/spec/ghb/git_hub_api_client_spec.rb
+++ b/spec/ghb/git_hub_api_client_spec.rb
@@ -185,6 +185,70 @@ RSpec.describe(GHB::GitHubAPIClient) do
     end
   end
 
+  describe '#graphql' do
+    let(:graphql_url) { 'https://api.github.com/graphql' }
+
+    it 'posts the query and variables and returns the data hash' do # rubocop:disable RSpec/ExampleLength
+      stub_request(:post, graphql_url)
+        .with(
+          body: { query: 'query { viewer { login } }', variables: { owner: 'org' } }.to_json,
+          headers: { Authorization: 'bearer test-token-123', Accept: 'application/json' }
+        )
+        .to_return(status: 200, body: { data: { viewer: { login: 'octocat' } } }.to_json)
+
+      expect(client.graphql('query { viewer { login } }', variables: { owner: 'org' }))
+        .to(eq(JSON.parse('{"viewer":{"login":"octocat"}}')))
+    end
+
+    it 'defaults variables to an empty hash' do
+      stub_request(:post, graphql_url)
+        .with(body: { query: 'query { viewer { login } }', variables: {} }.to_json)
+        .to_return(status: 200, body: '{"data":{}}')
+
+      expect(client.graphql('query { viewer { login } }')).to(eq({}))
+    end
+
+    # GraphQL reports failures inside a 200 response, so the status code alone
+    # would let a failed query look like a successful one.
+    it 'raises when a 200 response carries a GraphQL errors array' do
+      stub_request(:post, graphql_url)
+        .to_return(status: 200, body: { data: nil, errors: [{ message: 'Resource not accessible by integration' }, { message: 'Field does not exist' }] }.to_json)
+
+      expect { client.graphql('query { viewer { login } }') }
+        .to(raise_error(GHB::GitHubAPIError, 'GraphQL request failed: Resource not accessible by integration; Field does not exist'))
+    end
+
+    it 'ignores an empty errors array' do
+      stub_request(:post, graphql_url)
+        .to_return(status: 200, body: { data: { ok: true }, errors: [] }.to_json)
+
+      expect(client.graphql('query { viewer { login } }')).to(eq(JSON.parse('{"ok":true}')))
+    end
+
+    it 'returns an empty hash when data is null' do
+      stub_request(:post, graphql_url)
+        .to_return(status: 200, body: '{"data":null}')
+
+      expect(client.graphql('query { viewer { login } }')).to(eq({}))
+    end
+
+    it 'raises when the response body is not valid JSON' do
+      stub_request(:post, graphql_url)
+        .to_return(status: 200, body: '<html>maintenance</html>')
+
+      expect { client.graphql('query { viewer { login } }') }
+        .to(raise_error(GHB::GitHubAPIError, /GraphQL response was not valid JSON/))
+    end
+
+    it 'raises on an unexpected status code' do
+      stub_request(:post, graphql_url)
+        .to_return(status: 401, body: '{"message":"Bad credentials"}')
+
+      expect { client.graphql('query { viewer { login } }') }
+        .to(raise_error(GHB::GitHubAPIError, /HTTP POST.*graphql failed: 401/))
+    end
+  end
+
   describe 'retry logic' do
     it 'retries on 5xx responses' do # rubocop:disable RSpec/ExampleLength
       stub_request(:get, base_url)

--- a/spec/ghb/repository_configurator_spec.rb
+++ b/spec/ghb/repository_configurator_spec.rb
@@ -20,6 +20,24 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
     described_class.new(options: mock_options, required_status_checks: required_status_checks.dup, default_branch: default_branch)
   end
 
+  # Shape of the GraphQL force-push allowlist read. Defaults to a protected branch
+  # with nobody on the allowlist, which is the state every pre-existing example assumes.
+  # JSON.parse(...to_json) so the fixture has the string keys a real GraphQL
+  # response carries, without writing string-keyed hash literals by hand.
+  def branch_protection_rule_data(actors, rule_id: 'BPR_kwDOabcdef')
+    JSON.parse({ repository: { ref: { branchProtectionRule: branch_protection_rule(actors, rule_id) } } }.to_json)
+  end
+
+  def branch_protection_rule(actors, rule_id = 'BPR_kwDOabcdef')
+    {
+      id: rule_id,
+      allowsForcePushes: actors.any?,
+      # A nil actor becomes a null node, so fixtures can cover both shapes GitHub
+      # can hand back for an allowance it will not describe.
+      bypassForcePushAllowances: { nodes: actors.map { |actor| actor && { actor: actor } } }
+    }
+  end
+
   before do
     allow($stdout).to(receive(:puts))
     allow(ENV).to(receive(:fetch).with('GITHUB_TOKEN', nil).and_return(github_token))
@@ -28,6 +46,7 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
     allow(File).to(receive(:exist?).with('package.json').and_return(false))
     allow(File).to(receive(:exist?).with('.github/workflows/smoke.yml').and_return(false))
     allow(Dir).to(receive(:exist?).with('ci_scripts').and_return(false))
+    allow(github_client).to(receive(:graphql).and_return(branch_protection_rule_data([])))
   end
 
   describe '#configure' do # rubocop:disable RSpec/MultipleMemoizedHelpers
@@ -1399,6 +1418,168 @@ RSpec.describe(GHB::RepositoryConfigurator) do # rubocop:disable RSpec/MultipleM
             )
           )
         )
+      end
+    end
+
+    # allow_force_pushes: false in the REST PUT is silently ignored while a force-push
+    # actor allowlist exists, so asserting only that the `false` was *sent* passes on a
+    # branch that is still force-pushable. These examples assert the GraphQL state instead.
+    context 'when the default branch has a force-push actor allowlist' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:repo_info_response) do
+        instance_double(HTTParty::Response, code: 200, body: { private: false }.to_json)
+      end
+
+      let(:protection_response) do
+        instance_double(HTTParty::Response, code: 404, body: '{"message":"Not Found"}')
+      end
+
+      let(:codeql_default_setup_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:codeql_get_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:ok_response) do
+        instance_double(HTTParty::Response, code: 200, body: '{}')
+      end
+
+      let(:accepted_response) do
+        instance_double(HTTParty::Response, code: 202, body: '{}')
+      end
+
+      let(:allowed_actors) do
+        [
+          { __typename: 'User', login: 'force-pusher' },
+          { __typename: 'Team', slug: 'release-team' }
+        ]
+      end
+
+      let(:cleared_mutation_data) do
+        JSON.parse({ updateBranchProtectionRule: { branchProtectionRule: branch_protection_rule([]) } }.to_json)
+      end
+
+      before do
+        allow(github_client).to(receive(:get).with(repo_url).and_return(repo_info_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/branches/#{default_branch}/protection", expected_codes: [200, 404]).and_return(protection_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup", expected_codes: nil).and_return(codeql_default_setup_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/branches/#{default_branch}/protection", body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:post).with("#{repo_url}/branches/#{default_branch}/protection/required_signatures", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/vulnerability-alerts", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/automated-security-fixes", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:patch).with(repo_url, body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup").and_return(codeql_get_response))
+        allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: anything, expected_codes: [200, 202]).and_return(accepted_response))
+
+        allow(github_client).to(receive(:graphql).with(/\Aquery/, variables: anything).and_return(branch_protection_rule_data(allowed_actors)))
+        allow(github_client).to(receive(:graphql).with(/updateBranchProtectionRule/, variables: anything).and_return(cleared_mutation_data))
+      end
+
+      it 'clears the allowlist with an empty bypassForcePushActorIds mutation' do
+        configurator.configure
+
+        expect(github_client).to(have_received(:graphql).with(/bypassForcePushActorIds: \[\]/, variables: { ruleId: 'BPR_kwDOabcdef' }))
+      end
+
+      it 'names every actor still allowed to force push' do
+        expect { configurator.configure }
+          .to(output(/! User force-pusher.*! Team release-team/m).to_stderr)
+      end
+
+      it 'does not report success while the branch is still force-pushable' do
+        uncleared = JSON.parse({ updateBranchProtectionRule: { branchProtectionRule: branch_protection_rule(allowed_actors) } }.to_json)
+        allow(github_client).to(receive(:graphql).with(/updateBranchProtectionRule/, variables: anything).and_return(uncleared))
+
+        expect { configurator.configure }
+          .to(raise_error(RuntimeError, /force-push allowlist on master not cleared, still allows: User force-pusher, Team release-team/))
+      end
+
+      it 'fails loudly when the clearing mutation itself errors' do
+        allow(github_client).to(receive(:graphql).with(/updateBranchProtectionRule/, variables: anything).and_raise(GHB::GitHubAPIError, 'GraphQL request failed: Resource not accessible by integration'))
+
+        expect { configurator.configure }
+          .to(raise_error(RuntimeError, /could not clear the force-push allowlist on master: GraphQL request failed/))
+      end
+
+      it 'reports app actors and skips null or unnamed allowance nodes without crashing' do
+        allow(github_client).to(receive(:graphql).with(/\Aquery/, variables: anything).and_return(branch_protection_rule_data([nil, {}, { __typename: 'App', slug: 'renovate' }])))
+
+        expect { configurator.configure }
+          .to(output(/2 actor\(s\).*! Actor \(unnamed\).*! App renovate/m).to_stderr)
+      end
+    end
+
+    context 'when the default branch has an empty force-push allowlist' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:repo_info_response) do
+        instance_double(HTTParty::Response, code: 200, body: { private: false }.to_json)
+      end
+
+      let(:protection_response) do
+        instance_double(HTTParty::Response, code: 404, body: '{"message":"Not Found"}')
+      end
+
+      let(:codeql_default_setup_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:codeql_get_response) do
+        instance_double(HTTParty::Response, code: 200, body: { state: 'not-configured' }.to_json)
+      end
+
+      let(:ok_response) do
+        instance_double(HTTParty::Response, code: 200, body: '{}')
+      end
+
+      let(:accepted_response) do
+        instance_double(HTTParty::Response, code: 202, body: '{}')
+      end
+      let(:expected_query_variables) do
+        { owner: organization, repository: repository, qualifiedName: "refs/heads/#{default_branch}" }
+      end
+
+      before do
+        allow(github_client).to(receive(:get).with(repo_url).and_return(repo_info_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/branches/#{default_branch}/protection", expected_codes: [200, 404]).and_return(protection_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup", expected_codes: nil).and_return(codeql_default_setup_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/branches/#{default_branch}/protection", body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:post).with("#{repo_url}/branches/#{default_branch}/protection/required_signatures", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/vulnerability-alerts", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:put).with("#{repo_url}/automated-security-fixes", expected_codes: [200, 204]).and_return(ok_response))
+        allow(github_client).to(receive(:patch).with(repo_url, body: anything).and_return(ok_response))
+        allow(github_client).to(receive(:get).with("#{repo_url}/code-scanning/default-setup").and_return(codeql_get_response))
+        allow(github_client).to(receive(:patch).with("#{repo_url}/code-scanning/default-setup", body: anything, expected_codes: [200, 202]).and_return(accepted_response))
+      end
+
+      it 'reads the allowlist for the default branch ref' do
+        configurator.configure
+
+        expect(github_client).to(have_received(:graphql).with(/bypassForcePushAllowances/, variables: expected_query_variables))
+      end
+
+      it 'issues no clearing mutation' do
+        configurator.configure
+
+        expect(github_client).not_to(have_received(:graphql).with(/updateBranchProtectionRule/, variables: anything))
+      end
+
+      it 'emits no force-push warning' do
+        expect { configurator.configure }
+          .not_to(output(/force-push/).to_stderr)
+      end
+
+      it 'skips the allowlist check when the branch has no classic protection rule' do
+        allow(github_client).to(receive(:graphql).and_return(JSON.parse({ repository: { ref: { branchProtectionRule: nil } } }.to_json)))
+
+        expect { configurator.configure }
+          .not_to(raise_error)
+      end
+
+      it 'warns but keeps going when the allowlist cannot be read over GraphQL' do
+        allow(github_client).to(receive(:graphql).and_raise(GHB::GitHubAPIError, 'GraphQL request failed: Bad credentials'))
+
+        expect { configurator.configure }
+          .to(output(/could not read the force-push allowlist over GraphQL: GraphQL request failed: Bad credentials/).to_stderr)
       end
     end
   end


### PR DESCRIPTION
## Summary

`allow_force_pushes: false` in the branch-protection `PUT` is silently a no-op when the branch sits in GitHub's "Allow force pushes → Specify who can force push" mode. The `PUT` still returns `200` and the rest of the payload applies (in the run that found this, the required-check list synced 15 → 16 in the same request), but the actor allowlist survives, the branch stays force-pushable, and `github-build` prints `Repository settings configured successfully!`. The classic REST API cannot even represent that allowlist — it collapses "nobody may force push" and "only these actors may" into the same boolean — so a REST read-back cannot tell the fixed state from the broken one.

`GitHubAPIClient` gains a GraphQL path, and after the `PUT` the configurator reads `BranchProtectionRule.bypassForcePushAllowances` for the default branch, names every actor it finds, and clears the list via `updateBranchProtectionRule(bypassForcePushActorIds: [])`.

**Key changes:**

- `lib/ghb/github_api_client.rb`: adds `graphql(query, variables:)` — POSTs to `https://api.github.com/graphql` with bearer auth and returns the `data` hash. GraphQL reports failures inside a `200` response's `errors` array rather than through the status code, so those (and a non-JSON body) are raised as `GHB::GitHubAPIError` like any failed REST call.
- `lib/ghb/repository_configurator.rb`: adds `enforce_force_push_allowlist`, run after the branch-protection `PUT` and the required-signatures `POST`. It reads the allowlist, warns naming each actor (`User <login>` / `Team <slug>` / `App <slug>`), clears it, and re-verifies from the mutation's own result in the same round trip.
- An allowlist that survives clearing **raises**, so the run no longer reports success over a branch history anyone on the list can rewrite. A GraphQL read that fails (a token without GraphQL access, say) warns and lets the run continue — undetected drift is not the same as proven drift, and failing every run on a token-scope issue would be worse than the warning.
- `spec/ghb/repository_configurator_spec.rb`: 9 new examples covering the non-empty-allowlist path — clearing mutation shape, actor naming, the raise when the list survives, the raise when the mutation itself errors, null/unnamed allowance nodes, plus the unchanged-behavior cases (empty allowlist issues no mutation and no warning, no classic rule is a no-op, unreadable allowlist warns but continues). These assert the GraphQL state, not that `false` was *sent* — the old assertion at line 129 passes on a repo in exactly the wrong state.
- `spec/ghb/git_hub_api_client_spec.rb`: 7 new examples for `#graphql` — request shape and headers, `data` extraction, the `errors`-in-a-200 raise, empty/absent errors, null `data`, malformed JSON, and a non-200 status.
- `docs/architecture.md`: documents the GraphQL client method, the four new configurator methods, the extra step in the repository-settings flow, and the security rationale.

Found while investigating Cloud-Officer/aws#1068, where `master` had been force-pushable for a month across repeated full `github-build` runs.

Note for consumers: reading and clearing the allowlist needs a token with GraphQL access. Without it the run still completes, but prints a warning instead of verifying the branch.

Fixes #488

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [x] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
